### PR TITLE
Improved default settings for sparse index generation

### DIFF
--- a/spark-cobol/src/main/scala/za/co/absa/cobrix/spark/cobol/reader/parameters/ReaderParameters.scala
+++ b/spark-cobol/src/main/scala/za/co/absa/cobrix/spark/cobol/reader/parameters/ReaderParameters.scala
@@ -26,8 +26,9 @@ import za.co.absa.cobrix.spark.cobol.schema.SchemaRetentionPolicy.SchemaRetentio
   * @param lengthFieldName          A name of a field that contains record length. Optional. If not set the copybook record length will be used.
   * @param isRecordSequence         Does input files have 4 byte record length headers
   * @param isIndexGenerationNeeded  Is indexing input file before processing is requested
-  * @param inputSplitSizeMB         A partition size to target. In certain circumstances this size may not be exactly that, but the library will do the best effort to target that size
   * @param inputSplitRecords        The number of records to include in each partition. Notice mainframe records may have variable size, inputSplitMB is the recommended option
+  * @param inputSplitSizeMB         A partition size to target. In certain circumstances this size may not be exactly that, but the library will do the best effort to target that size
+  * @param hdfsDefaultBlockSize     Default HDFS block size for the HDFS filesystem used. This value is used as the default split size if inputSplitSizeMB is not specified
   * @param startOffset              An offset to the start of the record in each binary data block.
   * @param endOffset                An offset from the end of the record to the end of the binary data block.
   * @param generateRecordId         If true, a record id field will be prepended to each record.
@@ -42,6 +43,7 @@ case class ReaderParameters(
                              isIndexGenerationNeeded: Boolean = false,
                              inputSplitRecords: Option[Int] = None,
                              inputSplitSizeMB: Option[Int] = None,
+                             hdfsDefaultBlockSize: Option[Int] = None,
                              startOffset: Int = 0,
                              endOffset: Int = 0,
                              generateRecordId: Boolean = false,

--- a/spark-cobol/src/main/scala/za/co/absa/cobrix/spark/cobol/reader/varlen/VarLenNestedReader.scala
+++ b/spark-cobol/src/main/scala/za/co/absa/cobrix/spark/cobol/reader/varlen/VarLenNestedReader.scala
@@ -69,7 +69,7 @@ final class VarLenNestedReader(copybookContents: String,
   override def generateIndex(binaryData: SimpleStream, fileNumber: Int): ArrayBuffer[SparseIndexEntry] = {
     var recordSize = cobolSchema.getRecordSize
     val inputSplitSizeRecords: Option[Int] = readerProperties.inputSplitRecords
-    val inputSplitSizeMB: Option[Int] = readerProperties.inputSplitSizeMB
+    val inputSplitSizeMB: Option[Int] = getSplitSizeMB
 
     if (inputSplitSizeRecords.isDefined) {
       if (inputSplitSizeRecords.get < 1 || inputSplitSizeRecords.get > 1000000000) {
@@ -115,6 +115,14 @@ final class VarLenNestedReader(copybookContents: String,
     }
     if (readerProperties.endOffset < 0) {
       throw new IllegalArgumentException(s"Invalid record end offset = ${readerProperties.endOffset}. A record end offset cannot be negative.")
+    }
+  }
+
+  private def getSplitSizeMB: Option[Int] = {
+    if (readerProperties.inputSplitSizeMB.isDefined) {
+      readerProperties.inputSplitSizeMB
+    } else {
+      readerProperties.hdfsDefaultBlockSize
     }
   }
 }

--- a/spark-cobol/src/main/scala/za/co/absa/cobrix/spark/cobol/source/DefaultSource.scala
+++ b/spark-cobol/src/main/scala/za/co/absa/cobrix/spark/cobol/source/DefaultSource.scala
@@ -142,7 +142,11 @@ class DefaultSource
     val conf = spark.sparkContext.hadoopConfiguration
     val fileSystem = FileSystem.get(conf)
     val hdfsBlockSize = HDFSUtils.getHDFSDefaultBlockSizeMB(fileSystem)
-    logger.info(s"HDFS default block size = $hdfsBlockSize MB.")
+    hdfsBlockSize match {
+      case None => logger.info(s"Unable to get HDFS default block size.")
+      case Some(size) => logger.info(s"HDFS default block size = $size MB.")
+    }
+
     hdfsBlockSize
   }
 

--- a/spark-cobol/src/main/scala/za/co/absa/cobrix/spark/cobol/utils/HDFSUtils.scala
+++ b/spark-cobol/src/main/scala/za/co/absa/cobrix/spark/cobol/utils/HDFSUtils.scala
@@ -23,6 +23,7 @@ import org.apache.hadoop.fs.{FileSystem, Path}
   * This object provides utility methods for interacting with HDFS internals.
   */
 object HDFSUtils {
+  final val bytesInMegabyte = 1048576
 
   /**
     * Retrieves distinct block locations for a given HDFS file.
@@ -55,4 +56,27 @@ object HDFSUtils {
       .flatMap(_.getHosts)
       .distinct
   }
+
+  /**
+    * Returns the default block size of the HDFS filesystem in megabytes.
+    *
+    * @param fileSystem An HDFS filesystem
+    *
+    * @return A block size in megabytes and None in case of an error
+    */
+  def getHDFSDefaultBlockSizeMB(fileSystem: FileSystem): Option[Int] = {
+    val conf = fileSystem.getConf
+    val blockSizeInBytes = conf.get("dfs.blocksize").toLong
+    if (blockSizeInBytes > 0) {
+      val blockSizeInBM = (blockSizeInBytes / bytesInMegabyte).toInt
+      if (blockSizeInBM>0) {
+        Some (blockSizeInBM)
+      } else {
+        None
+      }
+    } else {
+      None
+    }
+  }
+
 }

--- a/spark-cobol/src/main/scala/za/co/absa/cobrix/spark/cobol/utils/HDFSUtils.scala
+++ b/spark-cobol/src/main/scala/za/co/absa/cobrix/spark/cobol/utils/HDFSUtils.scala
@@ -61,12 +61,14 @@ object HDFSUtils {
     * Returns the default block size of the HDFS filesystem in megabytes.
     *
     * @param fileSystem An HDFS filesystem
+    * @param path       An optional path can be provided if the default block size is path-dependent.
+    *                   The path should not have to exist.
     *
     * @return A block size in megabytes and None in case of an error
     */
-  def getHDFSDefaultBlockSizeMB(fileSystem: FileSystem): Option[Int] = {
-    val conf = fileSystem.getConf
-    val blockSizeInBytes = conf.get("dfs.blocksize").toLong
+  def getHDFSDefaultBlockSizeMB(fileSystem: FileSystem, path: Option[String] = None): Option[Int] = {
+    val hdfsPath = new Path(path.getOrElse("/"))
+    val blockSizeInBytes = fileSystem.getDefaultBlockSize(hdfsPath)
     if (blockSizeInBytes > 0) {
       val blockSizeInBM = (blockSizeInBytes / bytesInMegabyte).toInt
       if (blockSizeInBM>0) {


### PR DESCRIPTION
to achieve bettr data locality

* The default partition size is now equal to the default size of HDFS filesystem block
* The split is improved to achieve better alignment between Spark partitions and HDFS
  blocks.
