### PR TITLE
Feature/validate data vs copybook size

### DIFF
--- a/spark-cobol/src/main/scala/za/co/absa/cobrix/spark/cobol/source/scanners/CobolScanners.scala
+++ b/spark-cobol/src/main/scala/za/co/absa/cobrix/spark/cobol/source/scanners/CobolScanners.scala
@@ -16,6 +16,7 @@
 
 package za.co.absa.cobrix.spark.cobol.source.scanners
 
+import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.{FileSystem, Path}
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.{Row, SQLContext}
@@ -27,6 +28,7 @@ import za.co.absa.cobrix.spark.cobol.reader.varlen.VarLenReader
 import za.co.absa.cobrix.spark.cobol.source.SerializableConfiguration
 import za.co.absa.cobrix.spark.cobol.source.streaming.FileStreamer
 import za.co.absa.cobrix.spark.cobol.source.types.FileWithOrder
+import za.co.absa.cobrix.spark.cobol.utils.FileUtils
 
 private [source] object CobolScanners {
 
@@ -80,9 +82,28 @@ private [source] object CobolScanners {
     // https://spark.apache.org/docs/2.1.1/api/java/org/apache/spark/SparkContext.html#binaryFiles(java.lang.String,%20int)
 
     val recordSize = reader.getCobolSchema.getRecordSize + reader.getRecordStartOffset + reader.getRecordEndOffset
+
+    if (areThereNonDivisibleFiles(sourceDir, sqlContext.sparkContext.hadoopConfiguration, recordSize)) {
+      throw new IllegalArgumentException(s"There are some files in $sourceDir that are NOT DIVISIBLE by the calculated RECORD SIZE ($recordSize). Check the logs for the names of the files.")
+    }
+
     val schema = reader.getSparkSchema
 
     val records = sqlContext.sparkContext.binaryRecords(sourceDir, recordSize, sqlContext.sparkContext.hadoopConfiguration)
     recordParser(reader, records)
+  }
+
+  private def areThereNonDivisibleFiles(sourceDir: String, hadoopConfiguration: Configuration, divisor: Int): Boolean = {
+
+    val THRESHOLD_DIR_LENGTH_FOR_SINGLE_FILE_CHECK = 10000
+
+    val fileSystem = FileSystem.get(hadoopConfiguration)
+
+    if (FileUtils.getNumberOfFilesInDir(sourceDir, fileSystem) < THRESHOLD_DIR_LENGTH_FOR_SINGLE_FILE_CHECK) {
+      FileUtils.findAndLogAllNonDivisibleFiles(sourceDir, divisor, fileSystem) > 0
+    }
+    else {
+      FileUtils.findAndLogFirstNonDivisibleFile(sourceDir, divisor, fileSystem)
+    }
   }
 }

--- a/spark-cobol/src/main/scala/za/co/absa/cobrix/spark/cobol/source/scanners/CobolScanners.scala
+++ b/spark-cobol/src/main/scala/za/co/absa/cobrix/spark/cobol/source/scanners/CobolScanners.scala
@@ -84,7 +84,7 @@ private [source] object CobolScanners {
     val recordSize = reader.getCobolSchema.getRecordSize + reader.getRecordStartOffset + reader.getRecordEndOffset
 
     if (areThereNonDivisibleFiles(sourceDir, sqlContext.sparkContext.hadoopConfiguration, recordSize)) {
-      throw new IllegalArgumentException(s"There are some files in $sourceDir that are NOT DIVISIBLE by the calculated RECORD SIZE ($recordSize). Check the logs for the names of the files.")
+      throw new IllegalArgumentException(s"There are some files in $sourceDir that are NOT DIVISIBLE by the RECORD SIZE calculated from the copybook ($recordSize bytes per record). Check the logs for the names of the files.")
     }
 
     val schema = reader.getSparkSchema
@@ -95,7 +95,7 @@ private [source] object CobolScanners {
 
   private def areThereNonDivisibleFiles(sourceDir: String, hadoopConfiguration: Configuration, divisor: Int): Boolean = {
 
-    val THRESHOLD_DIR_LENGTH_FOR_SINGLE_FILE_CHECK = 10000
+    val THRESHOLD_DIR_LENGTH_FOR_SINGLE_FILE_CHECK = 50
 
     val fileSystem = FileSystem.get(hadoopConfiguration)
 

--- a/spark-cobol/src/main/scala/za/co/absa/cobrix/spark/cobol/utils/HDFSUtils.scala
+++ b/spark-cobol/src/main/scala/za/co/absa/cobrix/spark/cobol/utils/HDFSUtils.scala
@@ -17,7 +17,8 @@
 
 package za.co.absa.cobrix.spark.cobol.utils
 
-import org.apache.hadoop.fs.{FileSystem, Path}
+import org.apache.hadoop.fs.{FileStatus, FileSystem, Path}
+import org.slf4j.LoggerFactory
 
 /**
   * This object provides utility methods for interacting with HDFS internals.
@@ -80,5 +81,4 @@ object HDFSUtils {
       None
     }
   }
-
 }

--- a/spark-cobol/src/test/scala/za/co/absa/cobrix/spark/cobol/utils/FileUtilsSpec.scala
+++ b/spark-cobol/src/test/scala/za/co/absa/cobrix/spark/cobol/utils/FileUtilsSpec.scala
@@ -138,6 +138,35 @@ class FileUtilsSpec extends FlatSpec with BeforeAndAfterAll with BeforeAndAfterE
 
   it should "return 0 if there are no files inside a directory" in {
 
+    assertResult(0)(FileUtils.getNumberOfFilesInDir(controlledLengthFilesDir.getAbsolutePath, fileSystem))
+  }
+
+  it should "return 1 if there source is actually a file" in {
+
+    val aFile = getRandomFileToBeWritten
+    produceFileOfLength(aFile, 10)
+
+    assertResult(1)(FileUtils.getNumberOfFilesInDir(aFile.getAbsolutePath, fileSystem))
+  }
+
+  it should "return the file itself if non-divisible and if asked for first file" in {
+
+    val aFile = getRandomFileToBeWritten
+
+    val divisor = 10
+    produceFileOfLength(aFile, divisor + 1)
+
+    assertResult(true)(FileUtils.findAndLogFirstNonDivisibleFile(aFile.getAbsolutePath, divisor, fileSystem))
+  }
+
+  it should "return the file itself if non-divisible and if asked for multiple files" in {
+
+    val aFile = getRandomFileToBeWritten
+
+    val divisor = 10
+    produceFileOfLength(aFile, divisor + 1)
+
+    assertResult(1)(FileUtils.findAndLogAllNonDivisibleFiles(aFile.getAbsolutePath, divisor, fileSystem))
   }
 
   it should "return true if found first non-divisible file" in {

--- a/spark-cobol/src/test/scala/za/co/absa/cobrix/spark/cobol/utils/HDFSUtilsSpec.scala
+++ b/spark-cobol/src/test/scala/za/co/absa/cobrix/spark/cobol/utils/HDFSUtilsSpec.scala
@@ -20,13 +20,13 @@ import java.io.File
 import java.nio.charset.Charset
 import java.util.UUID
 
-import org.scalatest.{BeforeAndAfterAll, FlatSpec}
+import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach, FlatSpec}
 import org.spark_project.guava.io.Files
 import org.apache.commons.io.{FileUtils => CommonsFileUtils}
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.{FileSystem, Path}
 
-class HDFSUtilsSpec extends FlatSpec with BeforeAndAfterAll {
+class HDFSUtilsSpec extends FlatSpec with BeforeAndAfterAll with BeforeAndAfterEach {
 
   private val baseTestDir = TempDir.getNew
   private val validFile = new File(baseTestDir, "a_valid_file")
@@ -41,7 +41,6 @@ class HDFSUtilsSpec extends FlatSpec with BeforeAndAfterAll {
   override def afterAll(): Unit = {
     CommonsFileUtils.deleteDirectory(baseTestDir)
   }
-
 
   behavior of HDFSUtils.getClass.getName
 


### PR DESCRIPTION
Proactively checks the file sizes against record size calculated from the copybook before starting the Spark job.