### PR TITLE
Allow for top level Redefines.

### DIFF
--- a/cobol-parser/src/main/scala/za/co/absa/cobrix/cobol/parser/ast/Group.scala
+++ b/cobol-parser/src/main/scala/za/co/absa/cobrix/cobol/parser/ast/Group.scala
@@ -94,3 +94,7 @@ case class Group(
   }
 
 }
+
+object Group {
+  val root: Group = Group(level=0, name="_ROOT", lineNumber = -1)()
+}

--- a/cobol-parser/src/main/scala/za/co/absa/cobrix/cobol/parser/ast/Group.scala
+++ b/cobol-parser/src/main/scala/za/co/absa/cobrix/cobol/parser/ast/Group.scala
@@ -96,5 +96,5 @@ case class Group(
 }
 
 object Group {
-  val root: Group = Group(level=0, name="_ROOT", lineNumber = -1)()
+  val root: Group = Group(level=0, name="_ROOT_", lineNumber = -1)()
 }

--- a/cobol-parser/src/main/scala/za/co/absa/cobrix/cobol/parser/common/DataExtractors.scala
+++ b/cobol-parser/src/main/scala/za/co/absa/cobrix/cobol/parser/common/DataExtractors.scala
@@ -100,8 +100,8 @@ object DataExtractors {
     }
 
     var nextOffset = offset
-    val records = for (record <- ast) yield {
-      val values = getGroupValues(nextOffset, record)
+    val records = for (record <- ast.children) yield {
+      val values = getGroupValues(nextOffset, record.asInstanceOf[Group])
       nextOffset += record.binaryProperties.actualSize
       values
     }

--- a/cobol-parser/src/main/scala/za/co/absa/cobrix/cobol/parser/reader/iterator/FSRecordIterator.scala
+++ b/cobol-parser/src/main/scala/za/co/absa/cobrix/cobol/parser/reader/iterator/FSRecordIterator.scala
@@ -51,7 +51,7 @@ class FSRecordIterator (cobolSchema: Copybook, binaryFilePath: String) extends I
     val records = DataExtractors.extractValues(cobolSchema.getCobolSchema, bytes)
 
     // Advance byte index to the next record
-    val lastRecord = cobolSchema.getCobolSchema.last
+    val lastRecord = cobolSchema.getCobolSchema.children.last
     val lastRecordActualSize = lastRecord.binaryProperties.offset + lastRecord.binaryProperties.actualSize
     byteIndex += lastRecordActualSize
 

--- a/cobol-parser/src/test/scala/za/co/absa/cobrix/cobol/parser/decode/MalformedValuesSpec.scala
+++ b/cobol-parser/src/test/scala/za/co/absa/cobrix/cobol/parser/decode/MalformedValuesSpec.scala
@@ -18,7 +18,7 @@ package za.co.absa.cobrix.cobol.parser.decode
 
 import org.scalatest.FunSuite
 import za.co.absa.cobrix.cobol.parser.CopybookParser
-import za.co.absa.cobrix.cobol.parser.ast.Primitive
+import za.co.absa.cobrix.cobol.parser.ast.{Group, Primitive}
 
 class MalformedValuesSpec extends FunSuite {
 
@@ -29,7 +29,8 @@ class MalformedValuesSpec extends FunSuite {
         |""".stripMargin
 
     val copybook = CopybookParser.parseTree(copyBookContents)
-    val primitive = copybook.ast.head.children.head.asInstanceOf[Primitive]
+    val firstRecord = copybook.ast.children.head.asInstanceOf[Group]
+    val primitive = firstRecord.children.head.asInstanceOf[Primitive]
 
     // Encoded 8405184 is OK for Int32 and PIC 9(7)
     val data1 = Array(0x00.toByte, 0x80.toByte, 0x40.toByte, 0xC0.toByte)
@@ -49,7 +50,8 @@ class MalformedValuesSpec extends FunSuite {
         |""".stripMargin
 
     val copybook = CopybookParser.parseTree(copyBookContents)
-    val primitive = copybook.ast.head.children.head.asInstanceOf[Primitive]
+    val firstRecord = copybook.ast.children.head.asInstanceOf[Group]
+    val primitive = firstRecord.children.head.asInstanceOf[Primitive]
 
     // Encoded 12345.12345 is OK for Decimal and PIC 9(5)V9(5)
     val data1 = Array(0xF1.toByte, 0xF2.toByte, 0xF3.toByte, 0xF4.toByte, 0xF5.toByte, 0xF1.toByte, 0xF2.toByte, 0xF3.toByte, 0xF4.toByte, 0xF5.toByte)
@@ -81,14 +83,15 @@ class MalformedValuesSpec extends FunSuite {
         |""".stripMargin
 
     val copybook = CopybookParser.parseTree(copyBookContents)
-    val field1 = copybook.ast.head.children.head.asInstanceOf[Primitive]
-    val field2 = copybook.ast.head.children(1).asInstanceOf[Primitive]
-    val field3 = copybook.ast.head.children(2).asInstanceOf[Primitive]
-    val field4 = copybook.ast.head.children(3).asInstanceOf[Primitive]
-    val field5 = copybook.ast.head.children(4).asInstanceOf[Primitive]
-    val field6 = copybook.ast.head.children(5).asInstanceOf[Primitive]
-    val field7 = copybook.ast.head.children(6).asInstanceOf[Primitive]
-    val field8 = copybook.ast.head.children(7).asInstanceOf[Primitive]
+    val firstRecord = copybook.ast.children.head.asInstanceOf[Group]
+    val field1 = firstRecord.children.head.asInstanceOf[Primitive]
+    val field2 = firstRecord.children(1).asInstanceOf[Primitive]
+    val field3 = firstRecord.children(2).asInstanceOf[Primitive]
+    val field4 = firstRecord.children(3).asInstanceOf[Primitive]
+    val field5 = firstRecord.children(4).asInstanceOf[Primitive]
+    val field6 = firstRecord.children(5).asInstanceOf[Primitive]
+    val field7 = firstRecord.children(6).asInstanceOf[Primitive]
+    val field8 = firstRecord.children(7).asInstanceOf[Primitive]
 
     // Encoded 12 is OK since it is positive
     assert(field1.decodeTypeValue(0, Array(0xF1.toByte, 0xF2.toByte)) == 12)

--- a/cobol-parser/src/test/scala/za/co/absa/cobrix/cobol/parser/decode/UsageInheritanceSpec.scala
+++ b/cobol-parser/src/test/scala/za/co/absa/cobrix/cobol/parser/decode/UsageInheritanceSpec.scala
@@ -31,7 +31,8 @@ class UsageInheritanceSpec extends FunSuite {
         |""".stripMargin
 
     val copybook = CopybookParser.parseTree(copyBookContents)
-    val primitive = copybook.ast.head.children.head.asInstanceOf[Group].children.head.asInstanceOf[Primitive]
+    val firstRecord = copybook.ast.children.head.asInstanceOf[Group]
+    val primitive = firstRecord.children.head.asInstanceOf[Group].children.head.asInstanceOf[Primitive]
 
     val dataType = primitive.dataType
     val compact = dataType.asInstanceOf[za.co.absa.cobrix.cobol.parser.ast.datatype.Integral].compact
@@ -48,7 +49,8 @@ class UsageInheritanceSpec extends FunSuite {
         |""".stripMargin
 
     val copybook = CopybookParser.parseTree(copyBookContents)
-    val primitive = copybook.ast.head.children.head.asInstanceOf[Group].children.head.asInstanceOf[Primitive]
+    val firstRecord = copybook.ast.children.head.asInstanceOf[Group]
+    val primitive = firstRecord.children.head.asInstanceOf[Group].children.head.asInstanceOf[Primitive]
 
     val dataType = primitive.dataType
     val compact = dataType.asInstanceOf[za.co.absa.cobrix.cobol.parser.ast.datatype.Integral].compact
@@ -65,7 +67,8 @@ class UsageInheritanceSpec extends FunSuite {
         |""".stripMargin
 
     val copybook = CopybookParser.parseTree(copyBookContents)
-    val primitive = copybook.ast.head.children.head.asInstanceOf[Group].children.head.asInstanceOf[Primitive]
+    val firstRecord = copybook.ast.children.head.asInstanceOf[Group]
+    val primitive = firstRecord.children.head.asInstanceOf[Group].children.head.asInstanceOf[Primitive]
 
     val dataType = primitive.dataType
     val compact = dataType.asInstanceOf[za.co.absa.cobrix.cobol.parser.ast.datatype.Integral].compact
@@ -82,7 +85,8 @@ class UsageInheritanceSpec extends FunSuite {
         |""".stripMargin
 
     val copybook = CopybookParser.parseTree(copyBookContents)
-    val primitive = copybook.ast.head.children.head.asInstanceOf[Group].children.head.asInstanceOf[Primitive]
+    val firstRecord = copybook.ast.children.head.asInstanceOf[Group]
+    val primitive = firstRecord.children.head.asInstanceOf[Group].children.head.asInstanceOf[Primitive]
 
     val dataType = primitive.dataType
     val compact = dataType.asInstanceOf[za.co.absa.cobrix.cobol.parser.ast.datatype.Integral].compact

--- a/cobol-parser/src/test/scala/za/co/absa/cobrix/cobol/parser/extract/BinaryExtractorSpec.scala
+++ b/cobol-parser/src/test/scala/za/co/absa/cobrix/cobol/parser/extract/BinaryExtractorSpec.scala
@@ -139,7 +139,7 @@ class BinaryExtractorSpec extends FunSuite {
     }
 
     // check extracted values in the map
-    traverseAst(copybook.ast.head)
+    traverseAst(copybook.ast)
     assert(extractedData("ID").asInstanceOf[Int] === 6)
     assert(extractedData("SHORT_NAME").asInstanceOf[String] === "EXAMPLE4")
     assert(extractedData("NUMBER_OF_ACCTS").asInstanceOf[Int] === 3)

--- a/cobol-parser/src/test/scala/za/co/absa/cobrix/cobol/parser/parse/FieldSizeSpec.scala
+++ b/cobol-parser/src/test/scala/za/co/absa/cobrix/cobol/parser/parse/FieldSizeSpec.scala
@@ -36,7 +36,7 @@ class FieldSizeSpec extends FunSuite {
       |""".stripMargin
 
   def fieldsize(index: Int, cpy: Copybook): Int = {
-    val item = cpy.ast.head.children(index)
+    val item = cpy.ast.children.head.asInstanceOf[Group].children(index)
     val sizebits = item match {
       case grp: Group => grp.binaryProperties.actualSize
       case stat: Primitive => stat.binaryProperties.actualSize

--- a/cobol-parser/src/test/scala/za/co/absa/cobrix/cobol/parser/parse/SegmentRedefinesSpec.scala
+++ b/cobol-parser/src/test/scala/za/co/absa/cobrix/cobol/parser/parse/SegmentRedefinesSpec.scala
@@ -49,8 +49,8 @@ class SegmentRedefinesSpec extends FunSuite {
 
     val parsedCopybook = CopybookParser.parseTree(copybook, dropGroupFillers = false, segmentRedefines)
 
-    assert(parsedCopybook.ast.head.children(0).asInstanceOf[Group].isSegmentRedefine)
-    assert(!parsedCopybook.ast.head.children(1).asInstanceOf[Group].isSegmentRedefine)
+    assert(parsedCopybook.ast.children.head.asInstanceOf[Group].children(0).asInstanceOf[Group].isSegmentRedefine)
+    assert(!parsedCopybook.ast.children.head.asInstanceOf[Group].children(1).asInstanceOf[Group].isSegmentRedefine)
   }
 
   test ("Test segment redefines mark all redefines at root level") {
@@ -73,18 +73,18 @@ class SegmentRedefinesSpec extends FunSuite {
 
     val parsedCopybook = CopybookParser.parseTree(copybook, dropGroupFillers = false, segmentRedefinesOk)
 
-    // If a segment redefine is missing in the copybok an exception should be raised
+    // If a segment redefine is missing in the copybook an exception should be raised
     val exception1 = intercept[IllegalStateException] {
       CopybookParser.parseTree(copybook, dropGroupFillers = false, segmentRedefinesMissing)
     }
     assert(exception1.getMessage.contains("The following segment redefines not found: [ SEGMENT_D ]"))
 
     // Segment redefines should be correctly redefined
-    assert(!parsedCopybook.ast.head.children(0).asInstanceOf[Group].isSegmentRedefine)
-    assert(parsedCopybook.ast.head.children(1).asInstanceOf[Group].isSegmentRedefine)
-    assert(parsedCopybook.ast.head.children(2).asInstanceOf[Group].isSegmentRedefine)
-    assert(parsedCopybook.ast.head.children(3).asInstanceOf[Group].isSegmentRedefine)
-    assert(!parsedCopybook.ast.head.children(4).asInstanceOf[Group].isSegmentRedefine)
+    assert(!parsedCopybook.ast.children.head.asInstanceOf[Group].children(0).asInstanceOf[Group].isSegmentRedefine)
+    assert(parsedCopybook.ast.children.head.asInstanceOf[Group].children(1).asInstanceOf[Group].isSegmentRedefine)
+    assert(parsedCopybook.ast.children.head.asInstanceOf[Group].children(2).asInstanceOf[Group].isSegmentRedefine)
+    assert(parsedCopybook.ast.children.head.asInstanceOf[Group].children(3).asInstanceOf[Group].isSegmentRedefine)
+    assert(!parsedCopybook.ast.children.head.asInstanceOf[Group].children(4).asInstanceOf[Group].isSegmentRedefine)
   }
 
   test ("Test segment redefines should be in the same redefined group") {

--- a/cobol-parser/src/test/scala/za/co/absa/cobrix/cobol/parser/parse/SyntaxErrorsSpec.scala
+++ b/cobol-parser/src/test/scala/za/co/absa/cobrix/cobol/parser/parse/SyntaxErrorsSpec.scala
@@ -184,7 +184,8 @@ class SyntaxErrorsSpec extends FunSuite {
     // COMP-ACCOUNT-I is a valid field name. The parser should not be confused parsing it
     // although it contains 'COMP-'
     val copyBookContents =
-      """        12  ACCOUNT-DETAIL    OCCURS 80
+      """        12  NUMBER-OF-ACCTS      PIC 9(2).
+        |        12  ACCOUNT-DETAIL    OCCURS 80
         |               DEPENDING ON NUMBER-OF-ACCTS
         |               INDEXED BY COMP-ACCOUNT-I.
         |          15  ACCOUNT-NUMBER     PIC X(24).

--- a/spark-cobol/src/main/scala/za/co/absa/cobrix/spark/cobol/reader/fixedlen/iterator/FixedLenFlatRowIterator.scala
+++ b/spark-cobol/src/main/scala/za/co/absa/cobrix/spark/cobol/reader/fixedlen/iterator/FixedLenFlatRowIterator.scala
@@ -118,14 +118,14 @@ class FixedLenFlatRowIterator(val binaryData: Array[Byte], val cobolSchema: Cobo
     }
 
     var offset = byteIndex
-    val records = cobolSchema.getCobolSchema.ast.flatMap( record => {
-      val values = getGroupValues(offset, record)
+    val records = cobolSchema.getCobolSchema.ast.children.flatMap( record => {
+      val values = getGroupValues(offset, record.asInstanceOf[Group])
       offset += record.binaryProperties.actualSize
       values
     })
 
     // Advance byte index to the next record
-    val lastRecord = cobolSchema.getCobolSchema.ast.last
+    val lastRecord = cobolSchema.getCobolSchema.ast.children.last
     val lastRecordActualSize = lastRecord.binaryProperties.offset + lastRecord.binaryProperties.actualSize
     byteIndex += lastRecordActualSize
 

--- a/spark-cobol/src/main/scala/za/co/absa/cobrix/spark/cobol/reader/fixedlen/iterator/FixedLenMapIterator.scala
+++ b/spark-cobol/src/main/scala/za/co/absa/cobrix/spark/cobol/reader/fixedlen/iterator/FixedLenMapIterator.scala
@@ -130,14 +130,14 @@ class FixedLenMapIterator(val binaryData: Array[Byte], val cobolSchema: CobolSch
     }
 
     var offset = byteIndex
-    val records = cobolSchema.getCobolSchema.ast.flatMap( record => {
-      val values = getGroupValues(offset, record, s"${record.name}_")
+    val records = cobolSchema.getCobolSchema.ast.children.flatMap( record => {
+      val values = getGroupValues(offset, record.asInstanceOf[Group], s"${record.name}_")
       offset += record.binaryProperties.actualSize
       values
     })
 
     // Advance byte index to the next record
-    val lastRecord = cobolSchema.getCobolSchema.ast.last
+    val lastRecord = cobolSchema.getCobolSchema.ast.children.last
     val lastRecordActualSize = lastRecord.binaryProperties.offset + lastRecord.binaryProperties.actualSize
     byteIndex += lastRecordActualSize
 

--- a/spark-cobol/src/main/scala/za/co/absa/cobrix/spark/cobol/reader/fixedlen/iterator/FixedLenNestedRowIterator.scala
+++ b/spark-cobol/src/main/scala/za/co/absa/cobrix/spark/cobol/reader/fixedlen/iterator/FixedLenNestedRowIterator.scala
@@ -53,7 +53,7 @@ class FixedLenNestedRowIterator(val binaryData: Array[Byte],
     val records = RowExtractors.extractRecord(cobolSchema.getCobolSchema.ast, binaryData, offset, policy, generateRecordId = false)
 
     // Advance byte index to the next record
-    val lastRecord = cobolSchema.getCobolSchema.ast.last
+    val lastRecord = cobolSchema.getCobolSchema.ast.children.last
     val lastRecordActualSize = lastRecord.binaryProperties.offset + lastRecord.binaryProperties.actualSize
     byteIndex += lastRecordActualSize + endOffset
 

--- a/spark-cobol/src/main/scala/za/co/absa/cobrix/spark/cobol/schema/CobolSchema.scala
+++ b/spark-cobol/src/main/scala/za/co/absa/cobrix/spark/cobol/schema/CobolSchema.scala
@@ -53,8 +53,8 @@ class CobolSchema(val copybook: Copybook,
   @throws(classOf[IllegalStateException])
   private[this] lazy val sparkSchema = {
     logger.info("Layout positions:\n" + copybook.generateRecordLayoutPositions())
-    val records = for (record <- copybook.ast) yield {
-      parseGroup(record)
+    val records = for (record <- copybook.ast.children) yield {
+      parseGroup(record.asInstanceOf[Group])
     }
     val expandRecords = if (policy == SchemaRetentionPolicy.CollapseRoot) {
       // Expand root group fields
@@ -83,9 +83,9 @@ class CobolSchema(val copybook: Copybook,
   @throws(classOf[IllegalStateException])
   private[this] lazy val sparkFlatSchema = {
     logger.info("Layout positions:\n" + copybook.generateRecordLayoutPositions())
-    val arraySchema = copybook.ast.toArray
+    val arraySchema = copybook.ast.children.toArray
     val records = arraySchema.flatMap(record => {
-      parseGroupFlat(record, s"${record.name}_")
+      parseGroupFlat(record.asInstanceOf[Group], s"${record.name}_")
     })
     StructType(records)
   }

--- a/spark-cobol/src/main/scala/za/co/absa/cobrix/spark/cobol/utils/RowExtractors.scala
+++ b/spark-cobol/src/main/scala/za/co/absa/cobrix/spark/cobol/utils/RowExtractors.scala
@@ -141,8 +141,8 @@ object RowExtractors {
 
     var nextOffset = offsetBytes
 
-    val records = for (record <- ast) yield {
-      val values = getGroupValues(nextOffset, record)
+    val records = for (record <- ast.children) yield {
+      val values = getGroupValues(nextOffset, record.asInstanceOf[Group])
       nextOffset += record.binaryProperties.actualSize
       values
     }

--- a/spark-cobol/src/test/scala/za/co/absa/cobrix/spark/cobol/source/base/impl/DummyCobolSchema.scala
+++ b/spark-cobol/src/test/scala/za/co/absa/cobrix/spark/cobol/source/base/impl/DummyCobolSchema.scala
@@ -23,7 +23,7 @@ import za.co.absa.cobrix.cobol.parser.ast.Group
 
 import scala.collection.Seq
 
-class DummyCobolSchema(val sparkSchema: StructType) extends CobolSchema(new Copybook(Seq[Group]()), SchemaRetentionPolicy.KeepOriginal, false) with Serializable {
+class DummyCobolSchema(val sparkSchema: StructType) extends CobolSchema(new Copybook(Group.root), SchemaRetentionPolicy.KeepOriginal, false) with Serializable {
   override def getSparkSchema: StructType = sparkSchema
   override lazy val getRecordSize: Int = 40
 }


### PR DESCRIPTION
This PR solves the issue with top level redefines being counted as items with own size. Solves #72. 