### PR TITLE
#104 Add an option to suppress file size check

### DIFF
--- a/README.md
+++ b/README.md
@@ -857,6 +857,12 @@ You can change this behaviour if you would like to drop such filler groups by pr
 | .option("segment_id_level2", "SEGID-CLD2") | Specifies segment id value for child of a child level records. When this option is specified the Seg_Id2 field will be generated for each root record. You can use levels 3, 4 etc. |
 | .option("segment_id_prefix", "A_PREEFIX")  | Specifies a prefix to be added to each segment id value. This is to mage generated IDs globally unique. By default the prefix is the current timestamp in form of '201811122345_'. |
 
+##### Debug helper options
+
+|            Option (usage example)          |                           Description |
+| ------------------------------------------ |:----------------------------------------------------------------------------- |
+| .option("debug_ignore_file_size", "false") | If 'true' no exception will be thrown if record size does not match file size. Useful for debugging copybooks to make them match a data file. |
+
 ## Performance Analysis
 
 Performance tests were performed on synthetic datasets. The setup and results are as follows.

--- a/spark-cobol/src/main/scala/za/co/absa/cobrix/spark/cobol/source/DefaultSource.scala
+++ b/spark-cobol/src/main/scala/za/co/absa/cobrix/spark/cobol/source/DefaultSource.scala
@@ -54,7 +54,10 @@ class DefaultSource
     val cobolParameters = CobolParametersParser.parse(parameters)
     CobolParametersValidator.checkSanity(cobolParameters)
 
-    new CobolRelation(parameters(PARAM_SOURCE_PATH), buildEitherReader(sqlContext.sparkSession, cobolParameters), LocalityParameters.extract(cobolParameters))(sqlContext)
+    new CobolRelation(parameters(PARAM_SOURCE_PATH),
+      buildEitherReader(sqlContext.sparkSession, cobolParameters),
+      LocalityParameters.extract(cobolParameters),
+      cobolParameters.debugIgnoreFileSize)(sqlContext)
   }
 
   //TODO fix with the correct implementation once the correct Reader hierarchy is put in place.

--- a/spark-cobol/src/main/scala/za/co/absa/cobrix/spark/cobol/source/parameters/CobolParameters.scala
+++ b/spark-cobol/src/main/scala/za/co/absa/cobrix/spark/cobol/source/parameters/CobolParameters.scala
@@ -74,5 +74,6 @@ case class CobolParameters(
                             optimizeAllocation:    Boolean,
                             dropGroupFillers:      Boolean,
                             nonTerminals:          Seq[String],
-                            recordHeaderParser:    Option[String]
+                            recordHeaderParser:    Option[String],
+                            debugIgnoreFileSize:   Boolean
                           )

--- a/spark-cobol/src/main/scala/za/co/absa/cobrix/spark/cobol/source/parameters/CobolParametersParser.scala
+++ b/spark-cobol/src/main/scala/za/co/absa/cobrix/spark/cobol/source/parameters/CobolParametersParser.scala
@@ -75,6 +75,9 @@ object CobolParametersParser {
   val PARAM_OPTIMIZE_ALLOCATION       = "optimize_allocation"
   val PARAM_IMPROVE_LOCALITY          = "improve_locality"
 
+  // Parameters for debugging
+  val PARAM_DEBUG_IGNORE_FILE_SIZE    = "debug_ignore_file_size"
+
   private def getSchemaRetentionPolicy(params: Map[String,String]): SchemaRetentionPolicy = {
     val schemaRetentionPolicyName = params.getOrElse(PARAM_SCHEMA_RETENTION_POLICY, "keep_original")
     val schemaRetentionPolicy = SchemaRetentionPolicy.withNameOpt(schemaRetentionPolicyName)
@@ -144,7 +147,8 @@ object CobolParametersParser {
       params.getOrElse(PARAM_OPTIMIZE_ALLOCATION, "false").toBoolean,
       params.getOrElse(PARAM_GROUP_FILLERS, "false").toBoolean,
       params.getOrElse(PARAM_GROUP_NOT_TERMINALS, "").split(','),
-      params.get(PARAM_RECORD_HEADER_PARSER)
+      params.get(PARAM_RECORD_HEADER_PARSER),
+      params.getOrElse(PARAM_DEBUG_IGNORE_FILE_SIZE, "false").toBoolean
     )
   }
 

--- a/spark-cobol/src/main/scala/za/co/absa/cobrix/spark/cobol/source/scanners/CobolScanners.scala
+++ b/spark-cobol/src/main/scala/za/co/absa/cobrix/spark/cobol/source/scanners/CobolScanners.scala
@@ -75,6 +75,7 @@ private [source] object CobolScanners {
 
   private[source] def buildScanForFixedLength(reader: FixedLenReader, sourceDir: String,
                                               recordParser: (FixedLenReader,RDD[Array[Byte]]) => RDD[Row],
+                                              debugIgnoreFileSize: Boolean,
                                               sqlContext: SQLContext): RDD[Row] = {
     // This reads whole text files as RDD[String]
     // binaryRecords() for fixed size records
@@ -83,7 +84,7 @@ private [source] object CobolScanners {
 
     val recordSize = reader.getCobolSchema.getRecordSize + reader.getRecordStartOffset + reader.getRecordEndOffset
 
-    if (areThereNonDivisibleFiles(sourceDir, sqlContext.sparkContext.hadoopConfiguration, recordSize)) {
+    if (!debugIgnoreFileSize && areThereNonDivisibleFiles(sourceDir, sqlContext.sparkContext.hadoopConfiguration, recordSize)) {
       throw new IllegalArgumentException(s"There are some files in $sourceDir that are NOT DIVISIBLE by the RECORD SIZE calculated from the copybook ($recordSize bytes per record). Check the logs for the names of the files.")
     }
 

--- a/spark-cobol/src/test/scala/za/co/absa/cobrix/spark/cobol/source/CobolRelationSpec.scala
+++ b/spark-cobol/src/test/scala/za/co/absa/cobrix/spark/cobol/source/CobolRelationSpec.scala
@@ -59,7 +59,10 @@ class CobolRelationSpec extends SparkCobolTestBase with Serializable {
 
   it should "return an RDD[Row] if data are correct" in {
     val testReader: FixedLenReader = new DummyFixedLenReader(sparkSchema, cobolSchema, testData)(() => Unit)
-    val relation = new CobolRelation(copybookFile.getParentFile.getAbsolutePath, testReader, localityParams)(sqlContext)
+    val relation = new CobolRelation(copybookFile.getParentFile.getAbsolutePath,
+      testReader,
+      localityParams = localityParams,
+      debugIgnoreFileSize = false)(sqlContext)
     val cobolData: RDD[Row] = relation.parseRecords(testReader, oneRowRDD)
 
     val cobolDataFrame = sqlContext.createDataFrame(cobolData, sparkSchema)
@@ -80,7 +83,10 @@ class CobolRelationSpec extends SparkCobolTestBase with Serializable {
   it should "manage exceptions from Reader" in {
     val exceptionMessage = "exception expected message"
     val testReader: FixedLenReader = new DummyFixedLenReader(sparkSchema, cobolSchema, testData)(() => throw new Exception(exceptionMessage))
-    val relation = new CobolRelation(copybookFile.getParentFile.getAbsolutePath, testReader, localityParams)(sqlContext)
+    val relation = new CobolRelation(copybookFile.getParentFile.getAbsolutePath,
+      testReader,
+      localityParams = localityParams,
+      debugIgnoreFileSize = false)(sqlContext)
 
     val caught = intercept[Exception] {
       relation.parseRecords(testReader, oneRowRDD).collect()
@@ -92,7 +98,10 @@ class CobolRelationSpec extends SparkCobolTestBase with Serializable {
     val absentField = "absentField"
     val modifiedSparkSchema = sparkSchema.add(StructField(absentField, StringType, false))
     val testReader: FixedLenReader = new DummyFixedLenReader(modifiedSparkSchema, cobolSchema, testData)(() => Unit)
-    val relation = new CobolRelation(copybookFile.getParentFile.getAbsolutePath, testReader, localityParams)(sqlContext)
+    val relation = new CobolRelation(copybookFile.getParentFile.getAbsolutePath,
+      testReader,
+      localityParams = localityParams,
+      debugIgnoreFileSize = false)(sqlContext)
     
     val caught = intercept[SparkException] {
       relation.parseRecords(testReader, oneRowRDD).collect()

--- a/spark-cobol/src/test/scala/za/co/absa/cobrix/spark/cobol/source/integration/Test1FixedLengthRecordsSpec.scala
+++ b/spark-cobol/src/test/scala/za/co/absa/cobrix/spark/cobol/source/integration/Test1FixedLengthRecordsSpec.scala
@@ -45,7 +45,7 @@ class Test1FixedLengthRecordsSpec extends FunSuite with SparkTestBase {
       .load(inpudDataPath)
 
     // This is to print the actual output
-    println(df.schema.json)
+    //println(df.schema.json)
     //df.toJSON.take(60).foreach(println)
 
     val expectedSchema = Files.readAllLines(Paths.get(expectedSchemaPath), StandardCharsets.ISO_8859_1).toArray.mkString("\n")
@@ -64,6 +64,44 @@ class Test1FixedLengthRecordsSpec extends FunSuite with SparkTestBase {
       FileUtils.writeStringsToFile(actual, actualResultsPath)
       assert(false, s"The actual data doesn't match what is expected for $exampleName example. Please compare contents of $expectedResultsPath to $actualResultsPath for details.")
     }
+  }
+
+  test(s"Test failure on an invalid copybook") {
+    val copybook =
+      """        01  COMPANY-DETAILS.
+        |            05  SEGMENT-ID           PIC X(5).
+        |            05  COMPANY-ID           PIC X(11).
+        |""".stripMargin
+
+    val df1 = spark
+      .read
+      .format("cobol")
+      .option("copybook_contents", copybook)
+      .option("schema_retention_policy", "collapse_root")
+      .load(inpudDataPath)
+
+    val exception = intercept[IllegalArgumentException]{
+      df1.take(60).foreach(_ => true)
+    }
+    assert(exception.getMessage.contains("NOT DIVISIBLE by the RECORD SIZE"))
+  }
+
+  test(s"Test success on an invalid copybook with debug override") {
+    val copybook =
+      """        01  COMPANY-DETAILS.
+        |            05  SEGMENT-ID           PIC X(5).
+        |            05  COMPANY-ID           PIC X(11).
+        |""".stripMargin
+
+    val df1 = spark
+      .read
+      .format("cobol")
+      .option("copybook_contents", copybook)
+      .option("schema_retention_policy", "collapse_root")
+      .option("debug_ignore_file_size", "true")
+      .load(inpudDataPath)
+
+    df1.take(60).foreach(_ => true)
   }
 
 }


### PR DESCRIPTION
This is useful for debugging copybooks for fixed length records and making them mathc a data file.