### PR TITLE
#122 Fail the Spark Application if an option to 'spark-cobol' is not …

### DIFF
--- a/README.md
+++ b/README.md
@@ -875,7 +875,8 @@ You can change this behaviour if you would like to drop such filler groups by pr
 
 |            Option (usage example)          |                           Description |
 | ------------------------------------------ |:----------------------------------------------------------------------------- |
-| .option("debug_ignore_file_size", "false") | If 'true' no exception will be thrown if record size does not match file size. Useful for debugging copybooks to make them match a data file. |
+| .option("pedantic", "false")               | If 'true' (default) Cobrix will throw an exception is an unknown option is encountered. If 'false', unknown options will be logged as an error without failing Spark Application. |
+| .option("debug_ignore_file_size", "true")  | If 'true' no exception will be thrown if record size does not match file size. Useful for debugging copybooks to make them match a data file. |
 
 ## Performance Analysis
 

--- a/spark-cobol/src/main/scala/za/co/absa/cobrix/spark/cobol/source/DefaultSource.scala
+++ b/spark-cobol/src/main/scala/za/co/absa/cobrix/spark/cobol/source/DefaultSource.scala
@@ -29,7 +29,7 @@ import za.co.absa.cobrix.spark.cobol.reader.varlen.{VarLenNestedReader, VarLenRe
 import za.co.absa.cobrix.spark.cobol.source.copybook.CopybookContentLoader
 import za.co.absa.cobrix.spark.cobol.source.parameters.CobolParametersParser._
 import za.co.absa.cobrix.spark.cobol.source.parameters.{CobolParameters, CobolParametersParser, CobolParametersValidator, LocalityParameters}
-import za.co.absa.cobrix.spark.cobol.utils.{BuildProperties, HDFSUtils}
+import za.co.absa.cobrix.spark.cobol.utils.{BuildProperties, HDFSUtils, Parameters}
 
 /**
   * This class represents a Cobol data source.
@@ -53,7 +53,7 @@ class DefaultSource
 
     logger.info(s"Cobrix 'spark-cobol' build ${BuildProperties.buildVersion} (${BuildProperties.buildTimestamp}) ")
 
-    val cobolParameters = CobolParametersParser.parse(parameters)
+    val cobolParameters = CobolParametersParser.parse(new Parameters(parameters))
     CobolParametersValidator.checkSanity(cobolParameters)
 
     new CobolRelation(parameters(PARAM_SOURCE_PATH),

--- a/spark-cobol/src/main/scala/za/co/absa/cobrix/spark/cobol/utils/Parameters.scala
+++ b/spark-cobol/src/main/scala/za/co/absa/cobrix/spark/cobol/utils/Parameters.scala
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2018-2019 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.cobrix.spark.cobol.utils
+
+import scala.collection.mutable
+
+/**
+  * Wraps parameters provided by spark.read.option(...) in order to track which parameters are
+  * actually used/recognized.
+  *
+  * @param params Parameters provided by spark.read.option(...)
+  */
+class Parameters(params: Map[String, String]) {
+  private val usedKeys = new mutable.HashSet[String]
+
+  /**
+    * Gets a value from the underlying parameters map tracking its usage.
+    *
+    * @param key A key to the parameters map
+    * @return A value associated with the key
+    */
+  def apply(key: String): String = {
+    usedKeys += key
+    params(key)
+  }
+
+  /**
+    * Gets a value from the underlying parameters map tracking its usage.
+    *
+    * @param key A key to the parameters map
+    * @return An option boxed value associated with the key
+    */
+  def get(key: String): Option[String] = {
+    usedKeys += key
+    params.get(key)
+  }
+
+  /**
+    * Marks that a key is actually used by 'spark-cobol'. The method is used when options are
+    * processed by enumerating the underlying map.
+    *
+    * @param key A key to the parameters map
+    */
+  def markUsed(key: String): Unit = usedKeys += key
+
+  /**
+    * Returns true if a key is present in the underlying map tracking its usage.
+    *
+    * @param key A key to the parameters map
+    * @return True if the key is present in the map
+    */
+  def contains(key: String): Boolean = {
+    usedKeys += key
+    params.contains(key)
+  }
+
+  /**
+    * Gets a value from the underlying parameters map tracking its usage.
+    *
+    * @param key     A key to the parameters map
+    * @param default A default value that will be returned if the map does not contain the key.
+    * @return An value associated with the key or the default value if the key is not present in the map
+    */
+  def getOrElse(key: String, default: => String): String = {
+    usedKeys += key
+    params.getOrElse(key, default)
+  }
+
+  /**
+    * Returns the underlying map. This is used for getting spark-cobol options by enumerating the map itself.
+    *
+    * @return The underlying parameters map
+    */
+  def getMap: Map[String, String] = params
+
+  /**
+    * Returns the underlying map. This is used for getting spark-cobol options by enumerating the map itself.
+    *
+    * @return True is the provided key was used for determining how a COBOL data need to be processed.
+    */
+  def isKeyUsed(key: String): Boolean = {
+    usedKeys.contains(key)
+  }
+}

--- a/spark-cobol/src/test/scala/za/co/absa/cobrix/spark/cobol/source/ParametersParsingSpec.scala
+++ b/spark-cobol/src/test/scala/za/co/absa/cobrix/spark/cobol/source/ParametersParsingSpec.scala
@@ -18,6 +18,7 @@ package za.co.absa.cobrix.spark.cobol.source
 
 import org.scalatest.FunSuite
 import za.co.absa.cobrix.spark.cobol.source.parameters.CobolParametersParser
+import za.co.absa.cobrix.spark.cobol.utils.Parameters
 
 import scala.collection.immutable.HashMap
 
@@ -27,7 +28,7 @@ class ParametersParsingSpec extends FunSuite {
       "redefine-segment-id-map:0" -> "COMPANY => C,D",
       "redefine-segment-id-map:1" -> "CONTACT => P")
 
-    val segmentIdMapping = CobolParametersParser.getSegmentIdRedefineMapping(config)
+    val segmentIdMapping = CobolParametersParser.getSegmentIdRedefineMapping(new Parameters(config))
 
     assert(segmentIdMapping("C") == "COMPANY")
     assert(segmentIdMapping("D") == "COMPANY")

--- a/spark-cobol/src/test/scala/za/co/absa/cobrix/spark/cobol/source/integration/Test11CustomRDWParser.scala
+++ b/spark-cobol/src/test/scala/za/co/absa/cobrix/spark/cobol/source/integration/Test11CustomRDWParser.scala
@@ -63,7 +63,6 @@ class Test11CustomRDWParser extends FunSuite with SparkTestBase {
       .option("is_record_sequence", "true")
       .option("generate_record_id", "true")
       .option("schema_retention_policy", "collapse_root")
-      .option("segment_id_prefix", "A")
       .option("record_header_parser", "za.co.absa.cobrix.spark.cobol.source.utils.Test10CustomRDWParser")
       .option("rhp_additional_info", "rhp info")
       .load(inputDataPath)

--- a/spark-cobol/src/test/scala/za/co/absa/cobrix/spark/cobol/source/integration/Test1FixedLengthRecordsSpec.scala
+++ b/spark-cobol/src/test/scala/za/co/absa/cobrix/spark/cobol/source/integration/Test1FixedLengthRecordsSpec.scala
@@ -16,7 +16,6 @@
 
 package za.co.absa.cobrix.spark.cobol.source.integration
 
-import java.io.PrintWriter
 import java.nio.charset.StandardCharsets
 import java.nio.file.{Files, Paths}
 
@@ -102,6 +101,25 @@ class Test1FixedLengthRecordsSpec extends FunSuite with SparkTestBase {
       .load(inpudDataPath)
 
     df1.take(60).foreach(_ => true)
+  }
+
+  test(s"Test failure on unrecognized options") {
+    val copybook =
+      """        01  COMPANY-DETAILS.
+        |            05  SEGMENT-ID           PIC X(5).
+        |            05  COMPANY-ID           PIC X(11).
+        |""".stripMargin
+
+    val exception = intercept[IllegalArgumentException] {
+      val df1 = spark
+        .read
+        .format("cobol")
+        .option("copybook", inputCopybookPath)
+        .option("schema_retention_policy", "collapse_root")
+        .option("dummy", "unknown")
+        .load(inpudDataPath)
+    }
+    assert(exception.getMessage.contains("Redundant or unrecognized option(s) to 'spark-cobol': dummy."))
   }
 
 }


### PR DESCRIPTION
…recognized.

This behavior is overridable by
.option("pedantic", "false")