### PR TITLE
#135 Fix partitioning issues

### DIFF
--- a/spark-cobol/src/main/scala/za/co/absa/cobrix/spark/cobol/reader/varlen/VarLenNestedReader.scala
+++ b/spark-cobol/src/main/scala/za/co/absa/cobrix/spark/cobol/reader/varlen/VarLenNestedReader.scala
@@ -19,12 +19,12 @@ package za.co.absa.cobrix.spark.cobol.reader.varlen
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.types.StructType
 import org.slf4j.LoggerFactory
-import za.co.absa.cobrix.cobol.parser.{Copybook, CopybookParser}
 import za.co.absa.cobrix.cobol.parser.common.Constants
 import za.co.absa.cobrix.cobol.parser.encoding.codepage.CodePage
 import za.co.absa.cobrix.cobol.parser.encoding.{ASCII, EBCDIC}
 import za.co.absa.cobrix.cobol.parser.headerparsers.{RecordHeaderParser, RecordHeaderParserFactory}
 import za.co.absa.cobrix.cobol.parser.stream.SimpleStream
+import za.co.absa.cobrix.cobol.parser.{Copybook, CopybookParser}
 import za.co.absa.cobrix.spark.cobol.reader.index.IndexGenerator
 import za.co.absa.cobrix.spark.cobol.reader.index.entry.SparseIndexEntry
 import za.co.absa.cobrix.spark.cobol.reader.parameters.ReaderParameters
@@ -88,13 +88,13 @@ final class VarLenNestedReader(copybookContents: Seq[String],
       if (inputSplitSizeRecords.get < 1 || inputSplitSizeRecords.get > 1000000000) {
         throw new IllegalArgumentException(s"Invalid input split size. The requested number of records is ${inputSplitSizeRecords.get}.")
       }
-      logger.warn(s"Input split size = ${inputSplitSizeRecords.get} records")
+      logger.info(s"Input split size = ${inputSplitSizeRecords.get} records")
     } else {
       if (inputSplitSizeMB.nonEmpty) {
         if (inputSplitSizeMB.get < 1 || inputSplitSizeMB.get > 2000) {
           throw new IllegalArgumentException(s"Invalid input split size of ${inputSplitSizeMB.get} MB.")
         }
-        logger.warn(s"Input split size = ${inputSplitSizeMB.get} MB")
+        logger.info(s"Input split size = ${inputSplitSizeMB.get} MB")
       }
     }
 
@@ -102,11 +102,17 @@ final class VarLenNestedReader(copybookContents: Seq[String],
     val segmentIdField = ReaderParametersValidator.getSegmentIdField(readerProperties.multisegment, copybook)
     val segmentIfValue = readerProperties.multisegment.flatMap(a => a.segmentLevelIds.headOption).getOrElse("")
 
+    // It makes sense to parse data hierarchically only if hierarchical id generation is requested
+    val isHierarchical = readerProperties.multisegment match {
+      case Some(params) => params.segmentLevelIds.nonEmpty
+      case None => false
+    }
+
     segmentIdField match {
       case Some(field) => IndexGenerator.sparseIndexGenerator(fileNumber, binaryData, isRdwBigEndian,
-        recordHeaderParser, inputSplitSizeRecords, inputSplitSizeMB, Some(copybook), Some(field), segmentIfValue)
+        recordHeaderParser, inputSplitSizeRecords, inputSplitSizeMB, Some(copybook), Some(field), isHierarchical, segmentIfValue)
       case None => IndexGenerator.sparseIndexGenerator(fileNumber, binaryData, isRdwBigEndian,
-        recordHeaderParser, inputSplitSizeRecords, inputSplitSizeMB)
+        recordHeaderParser, inputSplitSizeRecords, inputSplitSizeMB, None, None, isHierarchical)
     }
   }
 

--- a/spark-cobol/src/main/scala/za/co/absa/cobrix/spark/cobol/reader/varlen/iterator/SegmentIdAccumulator.scala
+++ b/spark-cobol/src/main/scala/za/co/absa/cobrix/spark/cobol/reader/varlen/iterator/SegmentIdAccumulator.scala
@@ -51,7 +51,7 @@ final class SegmentIdAccumulator (segmentIds: Seq[String], segmentIdPrefix: Stri
     * @param level A level for which a value is requested
     * @return A Seg_Id value for the level
     */
-  def getSegmentLevelId(level: Int): Any = {
+  def getSegmentLevelId(level: Int): String = {
     if (level>=0 && level<=currentLevel) {
       if (level==0) {
         currentRootId

--- a/spark-cobol/src/main/scala/za/co/absa/cobrix/spark/cobol/reader/varlen/iterator/VarLenNestedIterator.scala
+++ b/spark-cobol/src/main/scala/za/co/absa/cobrix/spark/cobol/reader/varlen/iterator/VarLenNestedIterator.scala
@@ -98,7 +98,7 @@ final class VarLenNestedIterator(cobolSchema: Copybook,
           val segmentIdStr = segmentId.getOrElse("")
           val segmentLevelIds = getSegmentLevelIds(segmentIdStr)
 
-          if (isSegmentMatchesTheFilter(segmentIdStr)) {
+          if (isSegmentMatchesTheFilter(segmentIdStr, segmentLevelIds)) {
             val segmentRedefine = if (segmentRedefineAvailable) {
               segmentRedefineMap.getOrElse(segmentIdStr, "")
             } else ""
@@ -193,11 +193,11 @@ final class VarLenNestedIterator(cobolSchema: Copybook,
 
   // The gets all values for the helper fields for the current record having a specific segment id
   // It is deliberately wtitten imperative style for performance
-  private def getSegmentLevelIds(segmentId: String): Seq[Any] = {
+  private def getSegmentLevelIds(segmentId: String): Seq[String] = {
     if (segmentLevelIdsCount > 0 && segmentIdAccumulator.isDefined) {
       val acc = segmentIdAccumulator.get
       acc.acquiredSegmentId(segmentId, recordIndex)
-      val ids = new ListBuffer[Any]
+      val ids = new ListBuffer[String]
       var i = 0
       while (i < segmentLevelIdsCount) {
         ids += acc.getSegmentLevelId(i)
@@ -222,8 +222,14 @@ final class VarLenNestedIterator(cobolSchema: Copybook,
     )
   }
 
-  private def isSegmentMatchesTheFilter(segmentId: String): Boolean = {
-    segmentIdFilter
-      .forall(filter => filter.contains(segmentId))
+  private def isSegmentMatchesTheFilter(segmentId: String, segmentLevels: Seq[String]): Boolean = {
+    if (!isRootSegmentReached(segmentLevels)) {
+      false
+    } else {
+      segmentIdFilter
+        .forall(filter => filter.contains(segmentId))
+    }
   }
+
+  private def isRootSegmentReached(segmentLevels: Seq[String]): Boolean = segmentLevels.isEmpty || segmentLevels.head != null
 }

--- a/spark-cobol/src/test/scala/za/co/absa/cobrix/spark/cobol/source/integration/Test5MultisegmentSpec.scala
+++ b/spark-cobol/src/test/scala/za/co/absa/cobrix/spark/cobol/source/integration/Test5MultisegmentSpec.scala
@@ -42,7 +42,6 @@ class Test5MultisegmentSpec extends FunSuite with SparkTestBase {
   private val inputDataPathBigEndian = "../data/test5b_data"
 
   test(s"Integration test on $exampleName - segment ids, ebcdic") {
-    import spark.implicits._
 
     val expectedSchemaPath = "../data/test5_expected/test5_schema.json"
     val actualSchemaPath = "../data/test5_expected/test5_schema_actual.json"
@@ -94,7 +93,6 @@ class Test5MultisegmentSpec extends FunSuite with SparkTestBase {
   }
 
   test(s"Integration test on $exampleName - root segment id") {
-    import spark.implicits._
 
     // In this test we check that if only one segment id is specified the root segment ids should
     // still be correctly generated.
@@ -150,7 +148,6 @@ class Test5MultisegmentSpec extends FunSuite with SparkTestBase {
   }
 
   test(s"Integration test on $exampleName - auto resolve segment redefines") {
-    import spark.implicits._
 
     val expectedSchemaPath = "../data/test5_expected/test5c_schema.json"
     val actualSchemaPath = "../data/test5_expected/test5c_schema_actual.json"
@@ -216,12 +213,11 @@ class Test5MultisegmentSpec extends FunSuite with SparkTestBase {
     val recordHeaderParser = RecordHeaderParserFactory.createRecordHeaderParser(Constants.RhRdwLittleEndian, 0, 0, 0, 0)
     val indexes = IndexGenerator.sparseIndexGenerator(0, stream, isRdwBigEndian = false,
       recordHeaderParser = recordHeaderParser, recordsPerIndexEntry = Some(10),  sizePerIndexEntryMB = None,
-      copybook = Some(copybook), segmentField = Some(segmentIdField), rootSegmentId = segmentIdRootValue)
+      copybook = Some(copybook), segmentField = Some(segmentIdField), isHierarchical = true, rootSegmentId = segmentIdRootValue)
     assert(indexes.length == 88)
   }
 
   test(s"Integration test on $exampleName - big endian RDW") {
-    import spark.implicits._
 
     val expectedSchemaPath = "../data/test5_expected/test5b_schema.json"
     val actualSchemaPath = "../data/test5_expected/test5b_schema_actual.json"

--- a/spark-cobol/src/test/scala/za/co/absa/cobrix/spark/cobol/source/regression/Test02SparseIndexGenerator.scala
+++ b/spark-cobol/src/test/scala/za/co/absa/cobrix/spark/cobol/source/regression/Test02SparseIndexGenerator.scala
@@ -1,0 +1,208 @@
+/*
+ * Copyright 2018-2019 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.cobrix.spark.cobol.source.regression
+
+import java.io.{DataOutputStream, FileOutputStream}
+
+import org.apache.commons.io.{FileUtils => CommonsFileUtils}
+import org.scalatest.{BeforeAndAfterAll, FunSuite}
+import za.co.absa.cobrix.spark.cobol.source.base.SparkTestBase
+import za.co.absa.cobrix.spark.cobol.utils.TempDir
+
+class Test02SparseIndexGenerator extends FunSuite with BeforeAndAfterAll with SparkTestBase {
+
+  private val baseTestDir = TempDir.getNew
+
+  private val copybook =
+    """       01  R.
+           03 I       PIC 9(1).
+           03 D       PIC 9(1).
+    """
+
+  private val dataWithHeaderPath = baseTestDir + "/data_with_header.dat"
+  private val dataWithoutHeaderPath = baseTestDir + "/data_without_header.dat"
+  private val dataWithHeaderOnly = baseTestDir + "/header_only.dat"
+
+  override def beforeAll(): Unit = {
+    if (!baseTestDir.exists() || !baseTestDir.isDirectory) {
+      throw new IllegalArgumentException(s"Could not create test dir at ${baseTestDir.getAbsolutePath}")
+    }
+
+    val data = new DataOutputStream(new FileOutputStream(dataWithHeaderPath))
+    data.write(Array[Byte](0x00, 0x00, 0x01, 0x00, 0xF0.toByte))
+    (1 to 9).foreach { idx =>
+      data.write(Array[Byte](0x00, 0x00, 0x02, 0x00, 0xF1.toByte, (0xF0 + idx).toByte))
+    }
+    data.close()
+
+    val data2 = new DataOutputStream(new FileOutputStream(dataWithoutHeaderPath))
+    (1 to 9).foreach { idx =>
+      data2.write(Array[Byte](0x00, 0x00, 0x02, 0x00, 0xF1.toByte, (0xF0 + idx).toByte))
+    }
+    data2.close()
+
+    val data3 = new DataOutputStream(new FileOutputStream(dataWithHeaderOnly))
+    data3.write(Array[Byte](0x00, 0x00, 0x01, 0x00, 0xF0.toByte))
+    data3.close()
+  }
+
+  override def afterAll() {
+    CommonsFileUtils.deleteDirectory(baseTestDir)
+  }
+
+  test("Test data with header, no segment filter, no segment root") {
+    val df = spark
+      .read
+      .format("cobol")
+      .option("copybook_contents", copybook)
+      .option("generate_record_id", true)
+      .option("input_split_records", 5)
+      .option("is_xcom", true)
+      .load(dataWithHeaderPath)
+    println("Data With Header, No segment options # partitions: " + df.rdd.partitions.size)
+    assert(df.rdd.partitions.size == 2)
+    assert(df.count() == 10)
+  }
+
+  test("Test data with header, segment filter, no segment root") {
+    val df = spark
+      .read
+      .format("cobol")
+      .option("copybook_contents", copybook)
+      .option("generate_record_id", true)
+      .option("input_split_records", 5)
+      .option("is_xcom", true)
+      .option("segment_field", "I")
+      .option("segment_filter", "1")
+      .load(dataWithHeaderPath)
+    println("Data With Header, segment field and filter specified # partitions: " + df.rdd.partitions.size)
+    assert(df.rdd.partitions.size == 2)
+    assert(df.count() == 9)
+  }
+
+  test("Test data with header, segment filter, segment root") {
+    val df = spark
+      .read
+      .format("cobol")
+      .option("copybook_contents", copybook)
+      .option("generate_record_id", true)
+      .option("input_split_records", 5)
+      .option("is_xcom", true)
+      .option("segment_field", "I")
+      .option("segment_filter", "1,0")
+      .option("segment_id_root", "1")
+      .load(dataWithHeaderPath)
+    println("Data With Header, segment field, filter and id root specified # partitions: " + df.rdd.partitions.size)
+    assert(df.rdd.partitions.size == 2)
+    assert(df.count() == 9)
+  }
+
+  test("Test data without header, no segment filter, no segment root") {
+    val df = spark
+      .read
+      .format("cobol")
+      .option("copybook_contents", copybook)
+      .option("generate_record_id", true)
+      .option("input_split_records", 5)
+      .option("is_xcom", true)
+      .load(dataWithoutHeaderPath)
+    println("Data Without Header, No segment options # partitions: " + df.rdd.partitions.size)
+    assert(df.rdd.partitions.size == 2)
+    assert(df.count() == 9)
+  }
+
+  test("Test data without header, segment filter, no segment root") {
+    val df = spark
+      .read
+      .format("cobol")
+      .option("copybook_contents", copybook)
+      .option("generate_record_id", true)
+      .option("input_split_records", 5)
+      .option("is_xcom", true)
+      .option("segment_field", "I")
+      .option("segment_filter", "1")
+      .load(dataWithoutHeaderPath)
+    println("Data Without Header, segment field and filter specified # partitions: " + df.rdd.partitions.size)
+    assert(df.rdd.partitions.size == 2)
+    assert(df.count() == 9)
+  }
+
+  test("Test data without header, segment filter, segment root") {
+    val df = spark
+      .read
+      .format("cobol")
+      .option("copybook_contents", copybook)
+      .option("generate_record_id", true)
+      .option("input_split_records", 5)
+      .option("is_xcom", true)
+      .option("segment_field", "I")
+      .option("segment_filter", "1,0")
+      .option("segment_id_root", "1")
+      .load(dataWithoutHeaderPath)
+    println("Data Without Header, segment field, filter and id root specified # partitions: " + df.rdd.partitions.size)
+    assert(df.rdd.partitions.size == 2)
+    assert(df.count() == 9)
+  }
+
+  test("Test header only, no segment filter, no segment root") {
+    val df = spark
+      .read
+      .format("cobol")
+      .option("copybook_contents", copybook)
+      .option("generate_record_id", true)
+      .option("input_split_records", 5)
+      .option("is_xcom", true)
+      .load(dataWithHeaderOnly)
+    println("Data With Header only, No segment options # partitions: " + df.rdd.partitions.size)
+    assert(df.rdd.partitions.size == 1)
+    assert(df.count() == 1)
+  }
+
+  test("Test header only, segment filter, no segment root") {
+    val df = spark
+      .read
+      .format("cobol")
+      .option("copybook_contents", copybook)
+      .option("generate_record_id", true)
+      .option("input_split_records", 5)
+      .option("is_xcom", true)
+      .option("segment_field", "I")
+      .option("segment_filter", "1")
+      .load(dataWithHeaderOnly)
+    println("Data Header Only, segment field and filter specified # partitions: " + df.rdd.partitions.size)
+    assert(df.rdd.partitions.size == 1)
+    assert(df.count() == 0)
+  }
+
+  test("Test header only, segment filter, segment root") {
+    val df = spark
+      .read
+      .format("cobol")
+      .option("copybook_contents", copybook)
+      .option("generate_record_id", true)
+      .option("input_split_records", 5)
+      .option("is_xcom", true)
+      .option("segment_field", "I")
+      .option("segment_filter", "1,0")
+      .option("segment_id_root", "1")
+      .load(dataWithHeaderOnly)
+    println("Data Header Only, segment field, filter and id root specified # partitions: " + df.rdd.partitions.size)
+    assert(df.rdd.partitions.size == 1)
+    assert(df.count() == 0)
+  }
+
+}


### PR DESCRIPTION
* Hierarchical indexing is only used when level ids need to be generated
* Do not rely on segments having the same segment id should also have same size
* If the data IS hierarchical do not allow any record to be generated before
  any root segment is encountered. This is related to a scenario when
  file headers have the same segment id as root segments