### PR TITLE
Automatically generate license headers

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -200,3 +200,14 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
+
+------------------------------------------------------------------------------------
+This product bundles various third-party components under other open source licenses.
+This section summarizes those components and their licenses. See licenses/
+for text of these licenses.
+
+BSD 3-Clause
+------------
+
+2 methods in
+cobol-parser/src/main/scala/za/co/absa/cobrix/cobol/parser/decoders/FloatingPointDecoders.scala

--- a/build.sbt
+++ b/build.sbt
@@ -52,7 +52,7 @@ lazy val cobolParser = (project in file("cobol-parser"))
     libraryDependencies ++= CobolParserDependencies :+ getScalaDependency(scalaVersion.value),
     releasePublishArtifactsAction := PgpKeys.publishSigned.value,
     assemblySettings
-  )
+  ).enablePlugins(AutomateHeaderPlugin)
 
 lazy val cobolConverters = (project in file("cobol-converters"))
   .disablePlugins(sbtassembly.AssemblyPlugin)
@@ -61,6 +61,7 @@ lazy val cobolConverters = (project in file("cobol-converters"))
       libraryDependencies ++= CobolConvertersDependencies :+ getScalaDependency(scalaVersion.value),
       releasePublishArtifactsAction := PgpKeys.publishSigned.value
   ).dependsOn(cobolParser)
+  .enablePlugins(AutomateHeaderPlugin)
 
 lazy val sparkCobol = (project in file("spark-cobol"))
   .settings(
@@ -79,6 +80,7 @@ lazy val sparkCobol = (project in file("spark-cobol"))
     assemblySettings
   )
   .dependsOn(cobolParser)
+  .enablePlugins(AutomateHeaderPlugin)
 
 // scoverage settings
 ThisBuild / coverageExcludedPackages := ".*examples.*;.*replication.*"

--- a/cobol-parser/src/main/scala/za/co/absa/cobrix/cobol/parser/antlr/copybookLexer.java
+++ b/cobol-parser/src/main/scala/za/co/absa/cobrix/cobol/parser/antlr/copybookLexer.java
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-
 package za.co.absa.cobrix.cobol.parser.antlr;
 
 // Generated from copybookLexer.g4 by ANTLR 4.7.2

--- a/cobol-parser/src/main/scala/za/co/absa/cobrix/cobol/parser/antlr/copybookParser.java
+++ b/cobol-parser/src/main/scala/za/co/absa/cobrix/cobol/parser/antlr/copybookParser.java
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-
 package za.co.absa.cobrix.cobol.parser.antlr;
 
 // Generated from copybookParser.g4 by ANTLR 4.7.2

--- a/cobol-parser/src/main/scala/za/co/absa/cobrix/cobol/parser/antlr/copybookParserBaseVisitor.java
+++ b/cobol-parser/src/main/scala/za/co/absa/cobrix/cobol/parser/antlr/copybookParserBaseVisitor.java
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-
 package za.co.absa.cobrix.cobol.parser.antlr;
 
 // Generated from copybookParser.g4 by ANTLR 4.7.2

--- a/cobol-parser/src/main/scala/za/co/absa/cobrix/cobol/parser/antlr/copybookParserVisitor.java
+++ b/cobol-parser/src/main/scala/za/co/absa/cobrix/cobol/parser/antlr/copybookParserVisitor.java
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-
 package za.co.absa.cobrix.cobol.parser.antlr;
 
 // Generated from copybookParser.g4 by ANTLR 4.7.2

--- a/cobol-parser/src/main/scala/za/co/absa/cobrix/cobol/parser/antlr/jsonBaseVisitor.java
+++ b/cobol-parser/src/main/scala/za/co/absa/cobrix/cobol/parser/antlr/jsonBaseVisitor.java
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-
 package za.co.absa.cobrix.cobol.parser.antlr;
 
 // Generated from json.g4 by ANTLR 4.7.2

--- a/cobol-parser/src/main/scala/za/co/absa/cobrix/cobol/parser/antlr/jsonLexer.java
+++ b/cobol-parser/src/main/scala/za/co/absa/cobrix/cobol/parser/antlr/jsonLexer.java
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-
 package za.co.absa.cobrix.cobol.parser.antlr;
 
 // Generated from json.g4 by ANTLR 4.7.2

--- a/cobol-parser/src/main/scala/za/co/absa/cobrix/cobol/parser/antlr/jsonParser.java
+++ b/cobol-parser/src/main/scala/za/co/absa/cobrix/cobol/parser/antlr/jsonParser.java
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-
 package za.co.absa.cobrix.cobol.parser.antlr;
 
 // Generated from json.g4 by ANTLR 4.7.2

--- a/cobol-parser/src/main/scala/za/co/absa/cobrix/cobol/parser/antlr/jsonVisitor.java
+++ b/cobol-parser/src/main/scala/za/co/absa/cobrix/cobol/parser/antlr/jsonVisitor.java
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-
 package za.co.absa.cobrix.cobol.parser.antlr;
 
 // Generated from json.g4 by ANTLR 4.7.2

--- a/cobol-parser/src/main/scala/za/co/absa/cobrix/cobol/reader/FixedLenReader.scala
+++ b/cobol-parser/src/main/scala/za/co/absa/cobrix/cobol/reader/FixedLenReader.scala
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-
 package za.co.absa.cobrix.cobol.reader
 
 /** The abstract class for Cobol block (fixed length records) data readers from various sources */

--- a/cobol-parser/src/main/scala/za/co/absa/cobrix/cobol/reader/Reader.scala
+++ b/cobol-parser/src/main/scala/za/co/absa/cobrix/cobol/reader/Reader.scala
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-
 package za.co.absa.cobrix.cobol.reader
 
 import za.co.absa.cobrix.cobol.reader.schema.CobolSchema

--- a/cobol-parser/src/main/scala/za/co/absa/cobrix/cobol/reader/extractors/record/RecordHandler.scala
+++ b/cobol-parser/src/main/scala/za/co/absa/cobrix/cobol/reader/extractors/record/RecordHandler.scala
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-
 package za.co.absa.cobrix.cobol.reader.extractors.record
 
 import za.co.absa.cobrix.cobol.parser.ast.Group

--- a/spark-cobol/src/main/scala/za/co/absa/cobrix/spark/cobol/utils/HDFSUtils.scala
+++ b/spark-cobol/src/main/scala/za/co/absa/cobrix/spark/cobol/utils/HDFSUtils.scala
@@ -1,4 +1,3 @@
-
 /*
  * Copyright 2018 ABSA Group Limited
  *


### PR DESCRIPTION
Also, mention 2 methods licensed via BSD bundled with the Cobol parser.