### PR TITLE
#477 Fixed NotSerializableException when using non-default logger implementations

### DIFF
--- a/README.md
+++ b/README.md
@@ -1398,6 +1398,9 @@ at org.apache.hadoop.io.nativeio.NativeIO$POSIX.getStat(NativeIO.java:608)
 A: Update hadoop dll to version 3.2.2 or newer.
 
 ## Changelog
+- #### 2.4.9 (will be released soon).
+   - [#477](https://github.com/AbsaOSS/cobrix/issues/477) Fixed NotSerializableException when using non-default logger implementations.
+
 - #### 2.4.8 released 4 February 2022.
    - [#324](https://github.com/AbsaOSS/cobrix/issues/324) Allow removing of FILLERs from AST when parsing using 'parseSimple()'. The signature of the method has
      changed. The boolean arguments now reflect more clearly what they do.

--- a/cobol-parser/src/main/scala/za/co/absa/cobrix/cobol/internal/Logging.scala
+++ b/cobol-parser/src/main/scala/za/co/absa/cobrix/cobol/internal/Logging.scala
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2018 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.cobrix.cobol.internal
+
+import org.slf4j.{Logger, LoggerFactory}
+
+/**
+ * Utility trait for classes that want to log data. Creates a transient SLF4J logger for the class lazily
+ * so that objects with Logging can be serialized and used on another machine
+ */
+private[cobrix] trait Logging {
+
+  @transient private var log_ : Logger = null // scalastyle:ignore
+
+  protected def logName: String = {
+    this.getClass.getName.stripSuffix("$")
+  }
+
+  protected def logger: Logger = {
+    if (log_ == null) { // scalastyle:ignore
+      log_ = LoggerFactory.getLogger(logName)
+    }
+    log_
+  }
+
+}

--- a/cobol-parser/src/main/scala/za/co/absa/cobrix/cobol/parser/Copybook.scala
+++ b/cobol-parser/src/main/scala/za/co/absa/cobrix/cobol/parser/Copybook.scala
@@ -16,17 +16,15 @@
 
 package za.co.absa.cobrix.cobol.parser
 
-import org.slf4j.LoggerFactory
+import za.co.absa.cobrix.cobol.internal.Logging
 import za.co.absa.cobrix.cobol.parser.CopybookParser.CopybookAST
 import za.co.absa.cobrix.cobol.parser.ast.{Group, Primitive, Statement}
-import za.co.absa.cobrix.cobol.parser.common.Constants
 
 import scala.collection.mutable
 import scala.collection.mutable.ArrayBuffer
 
 
-class Copybook(val ast: CopybookAST) extends Serializable {
-  @transient private val logger = LoggerFactory.getLogger(this.getClass)
+class Copybook(val ast: CopybookAST) extends Logging with Serializable {
 
   def getCobolSchema: CopybookAST = ast
 

--- a/cobol-parser/src/main/scala/za/co/absa/cobrix/cobol/parser/Copybook.scala
+++ b/cobol-parser/src/main/scala/za/co/absa/cobrix/cobol/parser/Copybook.scala
@@ -26,7 +26,7 @@ import scala.collection.mutable.ArrayBuffer
 
 
 class Copybook(val ast: CopybookAST) extends Serializable {
-  private val logger = LoggerFactory.getLogger(this.getClass)
+  @transient private val logger = LoggerFactory.getLogger(this.getClass)
 
   def getCobolSchema: CopybookAST = ast
 

--- a/cobol-parser/src/main/scala/za/co/absa/cobrix/cobol/parser/CopybookParser.scala
+++ b/cobol-parser/src/main/scala/za/co/absa/cobrix/cobol/parser/CopybookParser.scala
@@ -16,9 +16,9 @@
 
 package za.co.absa.cobrix.cobol.parser
 
-import java.nio.charset.{Charset, StandardCharsets}
+import za.co.absa.cobrix.cobol.internal.Logging
 
-import org.slf4j.LoggerFactory
+import java.nio.charset.{Charset, StandardCharsets}
 import za.co.absa.cobrix.cobol.parser.antlr.ANTLRParser
 import za.co.absa.cobrix.cobol.parser.ast.datatype.{AlphaNumeric, Integral}
 import za.co.absa.cobrix.cobol.parser.ast.{BinaryProperties, Group, Primitive, Statement}
@@ -41,8 +41,7 @@ import scala.collection.mutable.{ArrayBuffer, ListBuffer}
 /**
   * The object contains generic function for the Copybook parser
   */
-object CopybookParser {
-  @transient private val logger = LoggerFactory.getLogger(this.getClass)
+object CopybookParser extends Logging {
 
   type CopybookAST = Group
 

--- a/cobol-parser/src/main/scala/za/co/absa/cobrix/cobol/parser/CopybookParser.scala
+++ b/cobol-parser/src/main/scala/za/co/absa/cobrix/cobol/parser/CopybookParser.scala
@@ -42,7 +42,7 @@ import scala.collection.mutable.{ArrayBuffer, ListBuffer}
   * The object contains generic function for the Copybook parser
   */
 object CopybookParser {
-  private val logger = LoggerFactory.getLogger(this.getClass)
+  @transient private val logger = LoggerFactory.getLogger(this.getClass)
 
   type CopybookAST = Group
 

--- a/cobol-parser/src/main/scala/za/co/absa/cobrix/cobol/parser/antlr/ANTLRParser.scala
+++ b/cobol-parser/src/main/scala/za/co/absa/cobrix/cobol/parser/antlr/ANTLRParser.scala
@@ -17,7 +17,7 @@
 package za.co.absa.cobrix.cobol.parser.antlr
 
 import org.antlr.v4.runtime._
-import org.slf4j.{Logger, LoggerFactory}
+import za.co.absa.cobrix.cobol.internal.Logging
 import za.co.absa.cobrix.cobol.parser.CopybookParser.CopybookAST
 import za.co.absa.cobrix.cobol.parser.decoders.FloatingPointFormat.FloatingPointFormat
 import za.co.absa.cobrix.cobol.parser.encoding.Encoding
@@ -49,8 +49,7 @@ class ThrowErrorStrategy() extends DefaultErrorStrategy {
 }
 
 
-object ANTLRParser {
-  @transient private val logger: Logger = LoggerFactory.getLogger(this.getClass)
+object ANTLRParser extends Logging {
 
   def parse(copyBookContents: String,
             enc: Encoding,

--- a/cobol-parser/src/main/scala/za/co/absa/cobrix/cobol/parser/antlr/ANTLRParser.scala
+++ b/cobol-parser/src/main/scala/za/co/absa/cobrix/cobol/parser/antlr/ANTLRParser.scala
@@ -50,7 +50,7 @@ class ThrowErrorStrategy() extends DefaultErrorStrategy {
 
 
 object ANTLRParser {
-  private val logger: Logger = LoggerFactory.getLogger(this.getClass)
+  @transient private val logger: Logger = LoggerFactory.getLogger(this.getClass)
 
   def parse(copyBookContents: String,
             enc: Encoding,

--- a/cobol-parser/src/main/scala/za/co/absa/cobrix/cobol/parser/antlr/ParserJson.scala
+++ b/cobol-parser/src/main/scala/za/co/absa/cobrix/cobol/parser/antlr/ParserJson.scala
@@ -22,7 +22,7 @@ import scala.collection.JavaConverters._
 
 
 class ParserJson {
-  private val logger: Logger = LoggerFactory.getLogger(this.getClass)
+  @transient private val logger: Logger = LoggerFactory.getLogger(this.getClass)
 
   def parse(text: String): Any = {
     val visitor = new ParserJsonVisitor()

--- a/cobol-parser/src/main/scala/za/co/absa/cobrix/cobol/parser/antlr/ParserJson.scala
+++ b/cobol-parser/src/main/scala/za/co/absa/cobrix/cobol/parser/antlr/ParserJson.scala
@@ -16,13 +16,12 @@
 
 package za.co.absa.cobrix.cobol.parser.antlr
 import org.antlr.v4.runtime.{BailErrorStrategy, CharStreams, CommonTokenStream}
-import org.slf4j.{Logger, LoggerFactory}
+import za.co.absa.cobrix.cobol.internal.Logging
 
 import scala.collection.JavaConverters._
 
 
-class ParserJson {
-  @transient private val logger: Logger = LoggerFactory.getLogger(this.getClass)
+class ParserJson extends Logging {
 
   def parse(text: String): Any = {
     val visitor = new ParserJsonVisitor()

--- a/cobol-parser/src/main/scala/za/co/absa/cobrix/cobol/parser/decoders/BinaryUtils.scala
+++ b/cobol-parser/src/main/scala/za/co/absa/cobrix/cobol/parser/decoders/BinaryUtils.scala
@@ -16,7 +16,6 @@
 
 package za.co.absa.cobrix.cobol.parser.decoders
 
-import org.slf4j.LoggerFactory
 import scodec.Codec
 import scodec.bits.BitVector
 import za.co.absa.cobrix.cobol.parser.ast.datatype._
@@ -28,7 +27,6 @@ import scala.util.control.NonFatal
 /** Utilites for decoding Cobol binary data files **/
 //noinspection RedundantBlock
 object BinaryUtils {
-  @transient private val logger = LoggerFactory.getLogger(this.getClass)
 
   lazy val floatB: Codec[Float] = scodec.codecs.float
   lazy val floatL: Codec[Float] = scodec.codecs.floatL

--- a/cobol-parser/src/main/scala/za/co/absa/cobrix/cobol/parser/decoders/BinaryUtils.scala
+++ b/cobol-parser/src/main/scala/za/co/absa/cobrix/cobol/parser/decoders/BinaryUtils.scala
@@ -28,7 +28,7 @@ import scala.util.control.NonFatal
 /** Utilites for decoding Cobol binary data files **/
 //noinspection RedundantBlock
 object BinaryUtils {
-  private val logger = LoggerFactory.getLogger(this.getClass)
+  @transient private val logger = LoggerFactory.getLogger(this.getClass)
 
   lazy val floatB: Codec[Float] = scodec.codecs.float
   lazy val floatL: Codec[Float] = scodec.codecs.floatL

--- a/cobol-parser/src/main/scala/za/co/absa/cobrix/cobol/parser/encoding/codepage/CodePage.scala
+++ b/cobol-parser/src/main/scala/za/co/absa/cobrix/cobol/parser/encoding/codepage/CodePage.scala
@@ -54,7 +54,7 @@ abstract class CodePage extends Serializable {
 }
 
 object CodePage {
-  val log: Logger = LoggerFactory.getLogger(this.getClass)
+  @transient val log: Logger = LoggerFactory.getLogger(this.getClass)
 
   def getCodePageByName(codePageName: String): CodePage = {
     codePageName match {

--- a/cobol-parser/src/main/scala/za/co/absa/cobrix/cobol/parser/encoding/codepage/CodePage.scala
+++ b/cobol-parser/src/main/scala/za/co/absa/cobrix/cobol/parser/encoding/codepage/CodePage.scala
@@ -16,7 +16,7 @@
 
 package za.co.absa.cobrix.cobol.parser.encoding.codepage
 
-import org.slf4j.{Logger, LoggerFactory}
+import za.co.absa.cobrix.cobol.internal.Logging
 
 /**
   * A trait for generalizing EBCDIC to ASCII conversion tables for different EBCDIC code pages.
@@ -53,8 +53,7 @@ abstract class CodePage extends Serializable {
   }
 }
 
-object CodePage {
-  @transient val log: Logger = LoggerFactory.getLogger(this.getClass)
+object CodePage extends Logging{
 
   def getCodePageByName(codePageName: String): CodePage = {
     codePageName match {
@@ -68,7 +67,7 @@ object CodePage {
   }
 
   def getCodePageByClass(codePageClass: String): CodePage = {
-    log.info(s"Instantiating code page class: $codePageClass")
+    logger.info(s"Instantiating code page class: $codePageClass")
     Class.forName(codePageClass,
                   true,
                   Thread.currentThread().getContextClassLoader)

--- a/cobol-parser/src/main/scala/za/co/absa/cobrix/cobol/parser/headerparsers/RecordHeaderParserFactory.scala
+++ b/cobol-parser/src/main/scala/za/co/absa/cobrix/cobol/parser/headerparsers/RecordHeaderParserFactory.scala
@@ -16,11 +16,10 @@
 
 package za.co.absa.cobrix.cobol.parser.headerparsers
 
-import org.slf4j.LoggerFactory
+import za.co.absa.cobrix.cobol.internal.Logging
 import za.co.absa.cobrix.cobol.parser.common.Constants
 
-object RecordHeaderParserFactory {
-  @transient private val logger = LoggerFactory.getLogger(this.getClass)
+object RecordHeaderParserFactory extends Logging {
 
   def createRecordHeaderParser(parserTypeOrClass: String,
                                recordLength: Int,

--- a/cobol-parser/src/main/scala/za/co/absa/cobrix/cobol/parser/headerparsers/RecordHeaderParserFactory.scala
+++ b/cobol-parser/src/main/scala/za/co/absa/cobrix/cobol/parser/headerparsers/RecordHeaderParserFactory.scala
@@ -20,7 +20,7 @@ import org.slf4j.LoggerFactory
 import za.co.absa.cobrix.cobol.parser.common.Constants
 
 object RecordHeaderParserFactory {
-  private val logger = LoggerFactory.getLogger(this.getClass)
+  @transient private val logger = LoggerFactory.getLogger(this.getClass)
 
   def createRecordHeaderParser(parserTypeOrClass: String,
                                recordLength: Int,

--- a/cobol-parser/src/main/scala/za/co/absa/cobrix/cobol/reader/VarLenNestedReader.scala
+++ b/cobol-parser/src/main/scala/za/co/absa/cobrix/cobol/reader/VarLenNestedReader.scala
@@ -16,8 +16,9 @@
 
 package za.co.absa.cobrix.cobol.reader
 
+import za.co.absa.cobrix.cobol.internal.Logging
+
 import java.nio.charset.{Charset, StandardCharsets}
-import org.slf4j.LoggerFactory
 import za.co.absa.cobrix.cobol.parser.common.Constants
 import za.co.absa.cobrix.cobol.parser.encoding.codepage.CodePage
 import za.co.absa.cobrix.cobol.parser.encoding.{ASCII, EBCDIC}
@@ -47,9 +48,7 @@ import scala.reflect.ClassTag
   */
 class VarLenNestedReader[T: ClassTag](copybookContents: Seq[String],
                                       readerProperties: ReaderParameters,
-                                      handler: RecordHandler[T]) extends VarLenReader with Serializable {
-
-  @transient private val logger = LoggerFactory.getLogger(this.getClass)
+                                      handler: RecordHandler[T]) extends VarLenReader with Logging with Serializable {
 
   protected val cobolSchema: CobolSchema = loadCopyBook(copybookContents)
 

--- a/cobol-parser/src/main/scala/za/co/absa/cobrix/cobol/reader/VarLenNestedReader.scala
+++ b/cobol-parser/src/main/scala/za/co/absa/cobrix/cobol/reader/VarLenNestedReader.scala
@@ -49,7 +49,7 @@ class VarLenNestedReader[T: ClassTag](copybookContents: Seq[String],
                                       readerProperties: ReaderParameters,
                                       handler: RecordHandler[T]) extends VarLenReader with Serializable {
 
-  private val logger = LoggerFactory.getLogger(this.getClass)
+  @transient private val logger = LoggerFactory.getLogger(this.getClass)
 
   protected val cobolSchema: CobolSchema = loadCopyBook(copybookContents)
 

--- a/cobol-parser/src/main/scala/za/co/absa/cobrix/cobol/reader/index/IndexGenerator.scala
+++ b/cobol-parser/src/main/scala/za/co/absa/cobrix/cobol/reader/index/IndexGenerator.scala
@@ -28,7 +28,7 @@ import za.co.absa.cobrix.cobol.reader.stream.SimpleStream
 import scala.collection.mutable.ArrayBuffer
 
 object IndexGenerator {
-  private val logger = LoggerFactory.getLogger(this.getClass)
+  @transient private val logger = LoggerFactory.getLogger(this.getClass)
 
   def sparseIndexGenerator(fileId: Int,
                            dataStream: SimpleStream,

--- a/cobol-parser/src/main/scala/za/co/absa/cobrix/cobol/reader/index/IndexGenerator.scala
+++ b/cobol-parser/src/main/scala/za/co/absa/cobrix/cobol/reader/index/IndexGenerator.scala
@@ -16,7 +16,7 @@
 
 package za.co.absa.cobrix.cobol.reader.index
 
-import org.slf4j.LoggerFactory
+import za.co.absa.cobrix.cobol.internal.Logging
 import za.co.absa.cobrix.cobol.parser.Copybook
 import za.co.absa.cobrix.cobol.parser.ast.Primitive
 import za.co.absa.cobrix.cobol.parser.headerparsers.RecordHeaderParser
@@ -27,8 +27,7 @@ import za.co.absa.cobrix.cobol.reader.stream.SimpleStream
 
 import scala.collection.mutable.ArrayBuffer
 
-object IndexGenerator {
-  @transient private val logger = LoggerFactory.getLogger(this.getClass)
+object IndexGenerator extends Logging {
 
   def sparseIndexGenerator(fileId: Int,
                            dataStream: SimpleStream,

--- a/cobol-parser/src/main/scala/za/co/absa/cobrix/cobol/reader/iterator/FixedLenNestedRowIterator.scala
+++ b/cobol-parser/src/main/scala/za/co/absa/cobrix/cobol/reader/iterator/FixedLenNestedRowIterator.scala
@@ -43,7 +43,7 @@ class FixedLenNestedRowIterator[T: ClassTag](
                                               handler: RecordHandler[T]
 ) extends Iterator[Seq[Any]] {
 
-  private val logger = LoggerFactory.getLogger(this.getClass)
+  @transient private val logger = LoggerFactory.getLogger(this.getClass)
 
   private val recordSize = readerProperties.recordLength.getOrElse(cobolSchema.getRecordSize)
   private var byteIndex = startOffset

--- a/cobol-parser/src/main/scala/za/co/absa/cobrix/cobol/reader/iterator/FixedLenNestedRowIterator.scala
+++ b/cobol-parser/src/main/scala/za/co/absa/cobrix/cobol/reader/iterator/FixedLenNestedRowIterator.scala
@@ -16,7 +16,7 @@
 
 package za.co.absa.cobrix.cobol.reader.iterator
 
-import org.slf4j.LoggerFactory
+import za.co.absa.cobrix.cobol.internal.Logging
 import za.co.absa.cobrix.cobol.reader.extractors.record.{RecordExtractors, RecordHandler}
 import za.co.absa.cobrix.cobol.reader.parameters.ReaderParameters
 import za.co.absa.cobrix.cobol.reader.policies.SchemaRetentionPolicy.SchemaRetentionPolicy
@@ -41,9 +41,7 @@ class FixedLenNestedRowIterator[T: ClassTag](
                                               endOffset: Int,
                                               singleRecordOnly: Boolean,
                                               handler: RecordHandler[T]
-) extends Iterator[Seq[Any]] {
-
-  @transient private val logger = LoggerFactory.getLogger(this.getClass)
+) extends Iterator[Seq[Any]] with Logging {
 
   private val recordSize = readerProperties.recordLength.getOrElse(cobolSchema.getRecordSize)
   private var byteIndex = startOffset

--- a/cobol-parser/src/main/scala/za/co/absa/cobrix/cobol/reader/iterator/VRLRecordReader.scala
+++ b/cobol-parser/src/main/scala/za/co/absa/cobrix/cobol/reader/iterator/VRLRecordReader.scala
@@ -16,7 +16,7 @@
 
 package za.co.absa.cobrix.cobol.reader.iterator
 
-import org.slf4j.LoggerFactory
+import za.co.absa.cobrix.cobol.internal.Logging
 import za.co.absa.cobrix.cobol.parser.Copybook
 import za.co.absa.cobrix.cobol.parser.headerparsers.RecordHeaderParser
 import za.co.absa.cobrix.cobol.reader.parameters.ReaderParameters
@@ -42,11 +42,9 @@ class VRLRecordReader(cobolSchema: Copybook,
                       recordHeaderParser: RecordHeaderParser,
                       recordExtractor: Option[RawRecordExtractor],
                       startRecordId: Long,
-                      startingFileOffset: Long) extends Iterator[(String, Array[Byte])]{
+                      startingFileOffset: Long) extends Iterator[(String, Array[Byte])] with Logging {
 
   type RawRecord = (String, Array[Byte])
-
-  @transient private val logger = LoggerFactory.getLogger(this.getClass)
 
   private var cachedValue: Option[RawRecord] = _
 

--- a/cobol-parser/src/main/scala/za/co/absa/cobrix/cobol/reader/iterator/VRLRecordReader.scala
+++ b/cobol-parser/src/main/scala/za/co/absa/cobrix/cobol/reader/iterator/VRLRecordReader.scala
@@ -46,7 +46,7 @@ class VRLRecordReader(cobolSchema: Copybook,
 
   type RawRecord = (String, Array[Byte])
 
-  private val logger = LoggerFactory.getLogger(this.getClass)
+  @transient private val logger = LoggerFactory.getLogger(this.getClass)
 
   private var cachedValue: Option[RawRecord] = _
 

--- a/cobol-parser/src/main/scala/za/co/absa/cobrix/cobol/reader/schema/CobolSchema.scala
+++ b/cobol-parser/src/main/scala/za/co/absa/cobrix/cobol/reader/schema/CobolSchema.scala
@@ -19,7 +19,6 @@ package za.co.absa.cobrix.cobol.reader.schema
 import java.time.ZonedDateTime
 import java.time.format.DateTimeFormatter
 
-import org.slf4j.{Logger, LoggerFactory}
 import za.co.absa.cobrix.cobol.parser.Copybook
 import za.co.absa.cobrix.cobol.reader.policies.SchemaRetentionPolicy.SchemaRetentionPolicy
 
@@ -41,8 +40,6 @@ class CobolSchema(val copybook: Copybook,
                   val generateRecordId: Boolean,
                   val generateSegIdFieldsCnt: Int = 0,
                   segmentIdProvidedPrefix: String = "") extends Serializable {
-
-  @transient protected val logger: Logger = LoggerFactory.getLogger(this.getClass)
 
   val segmentIdPrefix: String = if (segmentIdProvidedPrefix.isEmpty) getDefaultSegmentIdPrefix else segmentIdProvidedPrefix
 

--- a/cobol-parser/src/main/scala/za/co/absa/cobrix/cobol/reader/schema/CobolSchema.scala
+++ b/cobol-parser/src/main/scala/za/co/absa/cobrix/cobol/reader/schema/CobolSchema.scala
@@ -42,7 +42,7 @@ class CobolSchema(val copybook: Copybook,
                   val generateSegIdFieldsCnt: Int = 0,
                   segmentIdProvidedPrefix: String = "") extends Serializable {
 
-  protected val logger: Logger = LoggerFactory.getLogger(this.getClass)
+  @transient protected val logger: Logger = LoggerFactory.getLogger(this.getClass)
 
   val segmentIdPrefix: String = if (segmentIdProvidedPrefix.isEmpty) getDefaultSegmentIdPrefix else segmentIdProvidedPrefix
 

--- a/spark-cobol/src/main/scala/za/co/absa/cobrix/spark/cobol/parameters/CobolParametersParser.scala
+++ b/spark-cobol/src/main/scala/za/co/absa/cobrix/spark/cobol/parameters/CobolParametersParser.scala
@@ -16,7 +16,7 @@
 
 package za.co.absa.cobrix.spark.cobol.parameters
 
-import org.slf4j.LoggerFactory
+import za.co.absa.cobrix.cobol.internal.Logging
 import za.co.absa.cobrix.cobol.parser.CopybookParser
 import za.co.absa.cobrix.cobol.parser.antlr.ParserJson
 import za.co.absa.cobrix.cobol.parser.decoders.FloatingPointFormat
@@ -36,8 +36,7 @@ import scala.collection.mutable.ListBuffer
 /**
   * This class provides methods for parsing the parameters set as Spark options.
   */
-object CobolParametersParser {
-  @transient private val logger = LoggerFactory.getLogger(this.getClass)
+object CobolParametersParser extends Logging {
 
   val SHORT_NAME                      = "cobol"
   val PARAM_COPYBOOK_PATH             = "copybook"

--- a/spark-cobol/src/main/scala/za/co/absa/cobrix/spark/cobol/parameters/CobolParametersParser.scala
+++ b/spark-cobol/src/main/scala/za/co/absa/cobrix/spark/cobol/parameters/CobolParametersParser.scala
@@ -37,7 +37,7 @@ import scala.collection.mutable.ListBuffer
   * This class provides methods for parsing the parameters set as Spark options.
   */
 object CobolParametersParser {
-  private val logger = LoggerFactory.getLogger(this.getClass)
+  @transient private val logger = LoggerFactory.getLogger(this.getClass)
 
   val SHORT_NAME                      = "cobol"
   val PARAM_COPYBOOK_PATH             = "copybook"

--- a/spark-cobol/src/main/scala/za/co/absa/cobrix/spark/cobol/schema/CobolSchema.scala
+++ b/spark-cobol/src/main/scala/za/co/absa/cobrix/spark/cobol/schema/CobolSchema.scala
@@ -17,6 +17,7 @@
 package za.co.absa.cobrix.spark.cobol.schema
 
 import org.apache.spark.sql.types._
+import za.co.absa.cobrix.cobol.internal.Logging
 import za.co.absa.cobrix.cobol.parser.Copybook
 import za.co.absa.cobrix.cobol.parser.ast._
 import za.co.absa.cobrix.cobol.parser.ast.datatype.{AlphaNumeric, COMP1, COMP2, Decimal, Integral}
@@ -50,7 +51,7 @@ class CobolSchema(copybook: Copybook,
   extends CobolReaderSchema(
     copybook, policy, inputFileNameField, generateRecordId,
     generateSegIdFieldsCnt, segmentIdProvidedPrefix
-  ) with Serializable {
+  ) with Logging with Serializable {
 
   @throws(classOf[IllegalStateException])
   private[this] lazy val sparkSchema = createSparkSchema()

--- a/spark-cobol/src/main/scala/za/co/absa/cobrix/spark/cobol/source/CobolRelation.scala
+++ b/spark-cobol/src/main/scala/za/co/absa/cobrix/spark/cobol/source/CobolRelation.scala
@@ -72,7 +72,7 @@ class CobolRelation(sourceDirs: Seq[String],
     with Serializable
     with TableScan {
 
-  private val logger = LoggerFactory.getLogger(this.getClass)
+  @transient private val logger = LoggerFactory.getLogger(this.getClass)
 
   private val filesList = getListFilesWithOrder(sourceDirs)
 

--- a/spark-cobol/src/main/scala/za/co/absa/cobrix/spark/cobol/source/CobolRelation.scala
+++ b/spark-cobol/src/main/scala/za/co/absa/cobrix/spark/cobol/source/CobolRelation.scala
@@ -24,7 +24,6 @@ import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.sources.{BaseRelation, TableScan}
 import org.apache.spark.sql.types._
 import org.apache.spark.sql.{Row, SQLContext}
-import org.slf4j.LoggerFactory
 import za.co.absa.cobrix.spark.cobol.reader.{FixedLenReader, FixedLenTextReader, Reader, VarLenReader}
 import za.co.absa.cobrix.cobol.reader.index.entry.SparseIndexEntry
 import za.co.absa.cobrix.spark.cobol.source.index.IndexBuilder
@@ -71,8 +70,6 @@ class CobolRelation(sourceDirs: Seq[String],
   extends BaseRelation
     with Serializable
     with TableScan {
-
-  @transient private val logger = LoggerFactory.getLogger(this.getClass)
 
   private val filesList = getListFilesWithOrder(sourceDirs)
 

--- a/spark-cobol/src/main/scala/za/co/absa/cobrix/spark/cobol/source/DefaultSource.scala
+++ b/spark-cobol/src/main/scala/za/co/absa/cobrix/spark/cobol/source/DefaultSource.scala
@@ -20,7 +20,7 @@ import org.apache.hadoop.fs.FileSystem
 import org.apache.spark.sql.sources.{BaseRelation, DataSourceRegister, RelationProvider, SchemaRelationProvider}
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.sql.{SQLContext, SparkSession}
-import org.slf4j.LoggerFactory
+import za.co.absa.cobrix.cobol.internal.Logging
 import za.co.absa.cobrix.cobol.parser.encoding.codepage.CodePage
 import za.co.absa.cobrix.cobol.reader.parameters.{CobolParameters, ReaderParameters, VariableLengthParameters}
 import za.co.absa.cobrix.spark.cobol.parameters.CobolParametersParser._
@@ -37,9 +37,8 @@ class DefaultSource
   extends RelationProvider
     with SchemaRelationProvider
     with DataSourceRegister
-    with ReaderFactory {
-
-  @transient private val logger = LoggerFactory.getLogger(this.getClass)
+    with ReaderFactory
+    with Logging {
 
   override def shortName(): String = SHORT_NAME
 

--- a/spark-cobol/src/main/scala/za/co/absa/cobrix/spark/cobol/source/DefaultSource.scala
+++ b/spark-cobol/src/main/scala/za/co/absa/cobrix/spark/cobol/source/DefaultSource.scala
@@ -39,7 +39,7 @@ class DefaultSource
     with DataSourceRegister
     with ReaderFactory {
 
-  private val logger = LoggerFactory.getLogger(this.getClass)
+  @transient private val logger = LoggerFactory.getLogger(this.getClass)
 
   override def shortName(): String = SHORT_NAME
 

--- a/spark-cobol/src/main/scala/za/co/absa/cobrix/spark/cobol/source/index/IndexBuilder.scala
+++ b/spark-cobol/src/main/scala/za/co/absa/cobrix/spark/cobol/source/index/IndexBuilder.scala
@@ -22,7 +22,7 @@ import org.apache.hadoop.hdfs.DistributedFileSystem
 import org.apache.spark.SparkContext
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.SQLContext
-import org.slf4j.LoggerFactory
+import za.co.absa.cobrix.cobol.internal.Logging
 import za.co.absa.cobrix.cobol.reader.common.Constants
 import za.co.absa.cobrix.cobol.reader.index.entry.SparseIndexEntry
 import za.co.absa.cobrix.spark.cobol.reader.{Reader, VarLenReader}
@@ -42,9 +42,7 @@ import scala.collection.mutable.ArrayBuffer
   *
   * In a nutshell, ideally, there will be as many partitions as are there are indexes.
   */
-private[source] object IndexBuilder {
-
-  @transient private val logger = LoggerFactory.getLogger(this.getClass)
+private[source] object IndexBuilder extends Logging {
 
   def buildIndex(filesList: Array[FileWithOrder], cobolReader: Reader, sqlContext: SQLContext)(localityParams: LocalityParameters): RDD[SparseIndexEntry] = {
     val fs = new Path(filesList.head.filePath).getFileSystem(sqlContext.sparkSession.sparkContext.hadoopConfiguration)

--- a/spark-cobol/src/main/scala/za/co/absa/cobrix/spark/cobol/source/index/IndexBuilder.scala
+++ b/spark-cobol/src/main/scala/za/co/absa/cobrix/spark/cobol/source/index/IndexBuilder.scala
@@ -44,7 +44,7 @@ import scala.collection.mutable.ArrayBuffer
   */
 private[source] object IndexBuilder {
 
-  private val logger = LoggerFactory.getLogger(this.getClass)
+  @transient private val logger = LoggerFactory.getLogger(this.getClass)
 
   def buildIndex(filesList: Array[FileWithOrder], cobolReader: Reader, sqlContext: SQLContext)(localityParams: LocalityParameters): RDD[SparseIndexEntry] = {
     val fs = new Path(filesList.head.filePath).getFileSystem(sqlContext.sparkSession.sparkContext.hadoopConfiguration)

--- a/spark-cobol/src/main/scala/za/co/absa/cobrix/spark/cobol/source/scanners/CobolScanners.scala
+++ b/spark-cobol/src/main/scala/za/co/absa/cobrix/spark/cobol/source/scanners/CobolScanners.scala
@@ -33,7 +33,7 @@ import za.co.absa.cobrix.spark.cobol.utils.FileUtils
 
 private[source] object CobolScanners {
 
-  private val logger = LoggerFactory.getLogger(this.getClass)
+  @transient private val logger = LoggerFactory.getLogger(this.getClass)
 
   private[source] def buildScanForVarLenIndex(reader: VarLenReader, indexes: RDD[SparseIndexEntry], filesList: Array[FileWithOrder], sqlContext: SQLContext): RDD[Row] = {
     val filesMap = filesList.map(fileWithOrder => (fileWithOrder.order, fileWithOrder.filePath)).toMap

--- a/spark-cobol/src/main/scala/za/co/absa/cobrix/spark/cobol/source/scanners/CobolScanners.scala
+++ b/spark-cobol/src/main/scala/za/co/absa/cobrix/spark/cobol/source/scanners/CobolScanners.scala
@@ -17,12 +17,11 @@
 package za.co.absa.cobrix.spark.cobol.source.scanners
 
 import java.nio.charset.StandardCharsets
-
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.Path
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.{Row, SQLContext}
-import org.slf4j.LoggerFactory
+import za.co.absa.cobrix.cobol.internal.Logging
 import za.co.absa.cobrix.cobol.reader.common.Constants
 import za.co.absa.cobrix.cobol.reader.index.entry.SparseIndexEntry
 import za.co.absa.cobrix.spark.cobol.reader.{FixedLenReader, VarLenReader}
@@ -31,9 +30,7 @@ import za.co.absa.cobrix.spark.cobol.source.streaming.FileStreamer
 import za.co.absa.cobrix.spark.cobol.source.types.FileWithOrder
 import za.co.absa.cobrix.spark.cobol.utils.FileUtils
 
-private[source] object CobolScanners {
-
-  @transient private val logger = LoggerFactory.getLogger(this.getClass)
+private[source] object CobolScanners extends Logging {
 
   private[source] def buildScanForVarLenIndex(reader: VarLenReader, indexes: RDD[SparseIndexEntry], filesList: Array[FileWithOrder], sqlContext: SQLContext): RDD[Row] = {
     val filesMap = filesList.map(fileWithOrder => (fileWithOrder.order, fileWithOrder.filePath)).toMap

--- a/spark-cobol/src/main/scala/za/co/absa/cobrix/spark/cobol/utils/FileUtils.scala
+++ b/spark-cobol/src/main/scala/za/co/absa/cobrix/spark/cobol/utils/FileUtils.scala
@@ -19,10 +19,9 @@ package za.co.absa.cobrix.spark.cobol.utils
 import java.io.{FileOutputStream, OutputStreamWriter, PrintWriter}
 import java.nio.charset.StandardCharsets
 import java.nio.file.{Files, Paths}
-
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs._
-import org.slf4j.LoggerFactory
+import za.co.absa.cobrix.cobol.internal.Logging
 
 import scala.collection.JavaConverters._
 
@@ -33,9 +32,7 @@ import scala.collection.JavaConverters._
   *
   * Applies the same filter as Hadoop's FileInputFormat, which excludes files starting with '.' or '_'.
   */
-object FileUtils {
-
-  @transient private val logger = LoggerFactory.getLogger(this.getClass)
+object FileUtils extends Logging {
 
   val THRESHOLD_DIR_LENGTH_FOR_SINGLE_FILE_CHECK = 50
 

--- a/spark-cobol/src/main/scala/za/co/absa/cobrix/spark/cobol/utils/FileUtils.scala
+++ b/spark-cobol/src/main/scala/za/co/absa/cobrix/spark/cobol/utils/FileUtils.scala
@@ -35,7 +35,7 @@ import scala.collection.JavaConverters._
   */
 object FileUtils {
 
-  private val logger = LoggerFactory.getLogger(this.getClass)
+  @transient private val logger = LoggerFactory.getLogger(this.getClass)
 
   val THRESHOLD_DIR_LENGTH_FOR_SINGLE_FILE_CHECK = 50
 

--- a/spark-cobol/src/main/scala/za/co/absa/cobrix/spark/cobol/utils/SparkUtils.scala
+++ b/spark-cobol/src/main/scala/za/co/absa/cobrix/spark/cobol/utils/SparkUtils.scala
@@ -33,7 +33,7 @@ import scala.util.Try
   */
 object SparkUtils {
 
-  private val logger = LoggerFactory.getLogger(this.getClass)
+  @transient private val logger = LoggerFactory.getLogger(this.getClass)
 
   /**
     * Retrieves all executors available for the current job.

--- a/spark-cobol/src/main/scala/za/co/absa/cobrix/spark/cobol/utils/SparkUtils.scala
+++ b/spark-cobol/src/main/scala/za/co/absa/cobrix/spark/cobol/utils/SparkUtils.scala
@@ -21,7 +21,7 @@ import org.apache.spark.SparkContext
 import org.apache.spark.sql.functions.{concat_ws, expr, max}
 import org.apache.spark.sql.types._
 import org.apache.spark.sql.{Column, DataFrame}
-import org.slf4j.LoggerFactory
+import za.co.absa.cobrix.cobol.internal.Logging
 
 import scala.annotation.tailrec
 import scala.collection.mutable
@@ -31,9 +31,7 @@ import scala.util.Try
 /**
   * This object contains common Spark tools used for easier processing of dataframes originated from mainframes.
   */
-object SparkUtils {
-
-  @transient private val logger = LoggerFactory.getLogger(this.getClass)
+object SparkUtils extends Logging {
 
   /**
     * Retrieves all executors available for the current job.


### PR DESCRIPTION
https://github.com/AbsaOSS/cobrix/issues/477
 Make all loggers `@transient` for compatibility with non-default logger implementations