### PR TITLE
#553 Fix a regression bug introduced in #543 concerning variable OCCURS.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1517,7 +1517,7 @@ A: Update hadoop dll to version 3.2.2 or newer.
    - [#545](https://github.com/AbsaOSS/cobrix/issues/545) Added support for `string` debug columns for ASCII (D/D2/T) files (`.option("debug", "string")`).
    - [#542](https://github.com/AbsaOSS/cobrix/issues/542) Added `.option("filler_naming_policy", "previous_field_name")` allowing for a different filler naming strategy.
    - [#543](https://github.com/AbsaOSS/cobrix/issues/543) Improved performance of processing ASCII text (D/D2/T) files with variable OCCURS.
-   
+   - [#553](https://github.com/AbsaOSS/cobrix/issues/553) Fixed variable occurs now working properly with basic ASCII record format (D2).
 
 - #### 2.6.1 released 2 December 2022.
    - [#531](https://github.com/AbsaOSS/cobrix/issues/531) Added support for CP1047 EBCDIC code page.

--- a/cobol-parser/src/main/scala/za/co/absa/cobrix/cobol/reader/iterator/FixedLenNestedRowIterator.scala
+++ b/cobol-parser/src/main/scala/za/co/absa/cobrix/cobol/reader/iterator/FixedLenNestedRowIterator.scala
@@ -77,6 +77,7 @@ class FixedLenNestedRowIterator[T: ClassTag](
       binaryData,
       offset,
       policy,
+      readerProperties.variableSizeOccurs,
       activeSegmentRedefine = activeSegmentRedefine,
       handler = handler
     )

--- a/spark-cobol/src/main/scala/za/co/absa/cobrix/spark/cobol/source/scanners/CobolScanners.scala
+++ b/spark-cobol/src/main/scala/za/co/absa/cobrix/spark/cobol/source/scanners/CobolScanners.scala
@@ -102,7 +102,7 @@ private[source] object CobolScanners extends Logging {
       .reduce((a,b) => a.union(b))
 
     val records = rddText
-      .filter(str => str.length > 0)
+      .filter(str => str.nonEmpty)
       .map(str => {
         str.getBytes(StandardCharsets.UTF_8)
       })

--- a/spark-cobol/src/test/scala/za/co/absa/cobrix/spark/cobol/source/regression/Test13AsciiCrLfText.scala
+++ b/spark-cobol/src/test/scala/za/co/absa/cobrix/spark/cobol/source/regression/Test13AsciiCrLfText.scala
@@ -271,6 +271,7 @@ class Test13AsciiCrLfText extends AnyWordSpec with SparkTestBase with BinaryFile
         .option("copybook_contents", copybook2)
         .option("pedantic", "true")
         .option("record_format", "D")
+        .option("ascii_charset", "UTF-8")
         .option("input_split_records", 2)
         .load(tmpFileName)
 
@@ -379,6 +380,7 @@ class Test13AsciiCrLfText extends AnyWordSpec with SparkTestBase with BinaryFile
         .option("copybook_contents", copybook2)
         .option("pedantic", "true")
         .option("record_format", "D")
+        .option("ascii_charset", "UTF-8")
         .option("input_split_records", 2)
         .load(tmpFileName)
 

--- a/spark-cobol/src/test/scala/za/co/absa/cobrix/spark/cobol/source/regression/Test21VariableOccursForTextFiles.scala
+++ b/spark-cobol/src/test/scala/za/co/absa/cobrix/spark/cobol/source/regression/Test21VariableOccursForTextFiles.scala
@@ -36,20 +36,21 @@ class Test21VariableOccursForTextFiles extends AnyWordSpec with SparkTestBase wi
            03 INNER-GROUP OCCURS 0 TO 3 TIMES
                               DEPENDING ON INNER-COUNT.
               04 FIELD PIC X.
+        02 MARKER PIC X(1).
     """
 
   "ASCII files" should {
 
     val data =
-      """0
-        |01
-        |10
-        |11A
-        |12AB
-        |13ABC
-        |21AB
-        |22ABC
-        |23ABCD
+      """0M
+        |01M
+        |10M
+        |11AM
+        |12ABM
+        |13ABCM
+        |21A1BM
+        |22AB1CM
+        |23ABC1DM
         |""".stripMargin
 
     val expectedSchema =
@@ -61,21 +62,25 @@ class Test21VariableOccursForTextFiles extends AnyWordSpec with SparkTestBase wi
         | |    |    |-- INNER_GROUP: array (nullable = true)
         | |    |    |    |-- element: struct (containsNull = true)
         | |    |    |    |    |-- FIELD: string (nullable = true)
+        | |-- MARKER: string (nullable = true)
         |""".stripMargin
 
     val expectedData =
       """[ {
         |  "COUNT" : 0,
-        |  "GROUP" : [ ]
+        |  "GROUP" : [ ],
+        |  "MARKER" : "M"
         |}, {
         |  "COUNT" : 0,
-        |  "GROUP" : [ ]
+        |  "GROUP" : [ ],
+        |  "MARKER" : "1"
         |}, {
         |  "COUNT" : 1,
         |  "GROUP" : [ {
         |    "INNER_COUNT" : 0,
         |    "INNER_GROUP" : [ ]
-        |  } ]
+        |  } ],
+        |  "MARKER" : "M"
         |}, {
         |  "COUNT" : 1,
         |  "GROUP" : [ {
@@ -83,7 +88,8 @@ class Test21VariableOccursForTextFiles extends AnyWordSpec with SparkTestBase wi
         |    "INNER_GROUP" : [ {
         |      "FIELD" : "A"
         |    } ]
-        |  } ]
+        |  } ],
+        |  "MARKER" : "M"
         |}, {
         |  "COUNT" : 1,
         |  "GROUP" : [ {
@@ -93,7 +99,8 @@ class Test21VariableOccursForTextFiles extends AnyWordSpec with SparkTestBase wi
         |    }, {
         |      "FIELD" : "B"
         |    } ]
-        |  } ]
+        |  } ],
+        |  "MARKER" : "M"
         |}, {
         |  "COUNT" : 1,
         |  "GROUP" : [ {
@@ -105,7 +112,8 @@ class Test21VariableOccursForTextFiles extends AnyWordSpec with SparkTestBase wi
         |    }, {
         |      "FIELD" : "C"
         |    } ]
-        |  } ]
+        |  } ],
+        |  "MARKER" : "M"
         |}, {
         |  "COUNT" : 2,
         |  "GROUP" : [ {
@@ -114,8 +122,12 @@ class Test21VariableOccursForTextFiles extends AnyWordSpec with SparkTestBase wi
         |      "FIELD" : "A"
         |    } ]
         |  }, {
-        |    "INNER_GROUP" : [ { } ]
-        |  } ]
+        |    "INNER_COUNT" : 1,
+        |    "INNER_GROUP" : [ {
+        |      "FIELD" : "B"
+        |    } ]
+        |  } ],
+        |  "MARKER" : "M"
         |}, {
         |  "COUNT" : 2,
         |  "GROUP" : [ {
@@ -126,8 +138,12 @@ class Test21VariableOccursForTextFiles extends AnyWordSpec with SparkTestBase wi
         |      "FIELD" : "B"
         |    } ]
         |  }, {
-        |    "INNER_GROUP" : [ { }, { } ]
-        |  } ]
+        |    "INNER_COUNT" : 1,
+        |    "INNER_GROUP" : [ {
+        |      "FIELD" : "C"
+        |    } ]
+        |  } ],
+        |  "MARKER" : "M"
         |}, {
         |  "COUNT" : 2,
         |  "GROUP" : [ {
@@ -140,8 +156,12 @@ class Test21VariableOccursForTextFiles extends AnyWordSpec with SparkTestBase wi
         |      "FIELD" : "C"
         |    } ]
         |  }, {
-        |    "INNER_GROUP" : [ { }, { }, { } ]
-        |  } ]
+        |    "INNER_COUNT" : 1,
+        |    "INNER_GROUP" : [ {
+        |      "FIELD" : "D"
+        |    } ]
+        |  } ],
+        |  "MARKER" : "M"
         |} ]
         |""".stripMargin.replace("\r\n", "\n")
 


### PR DESCRIPTION
Variable OCCURS resulted with null fields after the OCCURS field when record_format=D. This is now fixed.