### PR TITLE
Release Cobrix v.2.6.9

### DIFF
--- a/.github/workflows/jacoco_check.yml
+++ b/.github/workflows/jacoco_check.yml
@@ -37,9 +37,9 @@ jobs:
         # Scala 2.12 is chosen since it is supported by the most wide range of Spark versions and
         # vendor distributions.
         include:
-          - scala: 2.12.17
+          - scala: 2.12.18
             scalaShort: "2.12"
-            spark: 3.3.2
+            spark: 3.3.3
             overall: 0.0
             changed: 80.0
 

--- a/README.md
+++ b/README.md
@@ -1643,6 +1643,10 @@ at org.apache.hadoop.io.nativeio.NativeIO$POSIX.getStat(NativeIO.java:608)
 A: Update hadoop dll to version 3.2.2 or newer.
 
 ## Changelog
+- #### 2.6.8 released 16 October 2023.
+   - [#634](https://github.com/AbsaOSS/cobrix/issues/634) Retain metadata when flattening the schema in SparkUtils.
+   - [#644](https://github.com/AbsaOSS/cobrix/issues/644) Add support for Spark 3.5.0.
+
 - #### 2.6.8 released 1 June 2023.
    - [#624](https://github.com/AbsaOSS/cobrix/issues/624) Add support for binary fields that have `PIC X` and `USAGE COMP`.
 

--- a/README.md
+++ b/README.md
@@ -74,13 +74,13 @@ You can link against this library in your program at the following coordinates:
 </tr>
 <tr>
 <td>
-<pre>groupId: za.co.absa.cobrix<br>artifactId: spark-cobol_2.11<br>version: 2.6.8</pre>
+<pre>groupId: za.co.absa.cobrix<br>artifactId: spark-cobol_2.11<br>version: 2.6.9</pre>
 </td>
 <td>
-<pre>groupId: za.co.absa.cobrix<br>artifactId: spark-cobol_2.12<br>version: 2.6.8</pre>
+<pre>groupId: za.co.absa.cobrix<br>artifactId: spark-cobol_2.12<br>version: 2.6.9</pre>
 </td>
 <td>
-<pre>groupId: za.co.absa.cobrix<br>artifactId: spark-cobol_2.13<br>version: 2.6.8</pre>
+<pre>groupId: za.co.absa.cobrix<br>artifactId: spark-cobol_2.13<br>version: 2.6.9</pre>
 </td>
 </tr>
 </table>
@@ -91,17 +91,17 @@ This package can be added to Spark using the `--packages` command line option. F
 
 ### Spark compiled with Scala 2.11
 ```
-$SPARK_HOME/bin/spark-shell --packages za.co.absa.cobrix:spark-cobol_2.11:2.6.8
+$SPARK_HOME/bin/spark-shell --packages za.co.absa.cobrix:spark-cobol_2.11:2.6.9
 ```
 
 ### Spark compiled with Scala 2.12
 ```
-$SPARK_HOME/bin/spark-shell --packages za.co.absa.cobrix:spark-cobol_2.12:2.6.8
+$SPARK_HOME/bin/spark-shell --packages za.co.absa.cobrix:spark-cobol_2.12:2.6.9
 ```
 
 ### Spark compiled with Scala 2.13
 ```
-$SPARK_HOME/bin/spark-shell --packages za.co.absa.cobrix:spark-cobol_2.13:2.6.8
+$SPARK_HOME/bin/spark-shell --packages za.co.absa.cobrix:spark-cobol_2.13:2.6.9
 ```
 
 ## Usage
@@ -238,17 +238,17 @@ to decode various binary formats.
 
 The jars that you need to get are:
 
-* spark-cobol_2.12-2.6.8.jar
-* cobol-parser_2.12-2.6.8.jar
+* spark-cobol_2.12-2.6.9.jar
+* cobol-parser_2.12-2.6.9.jar
 * scodec-core_2.12-1.10.3.jar
 * scodec-bits_2.12-1.1.4.jar
 * antlr4-runtime-4.8.jar 
 
 After that you can specify these jars in `spark-shell` command line. Here is an example:
 ```
-$ spark-shell --packages za.co.absa.cobrix:spark-cobol_2.12:2.6.8
+$ spark-shell --packages za.co.absa.cobrix:spark-cobol_2.12:2.6.9
 or 
-$ spark-shell --master yarn --deploy-mode client --driver-cores 4 --driver-memory 4G --jars spark-cobol_2.12-2.6.8.jar,cobol-parser_2.12-2.6.8.jar,scodec-core_2.12-1.10.3.jar,scodec-bits_2.12-1.1.4.jar,antlr4-runtime-4.8.jar
+$ spark-shell --master yarn --deploy-mode client --driver-cores 4 --driver-memory 4G --jars spark-cobol_2.12-2.6.9.jar,cobol-parser_2.12-2.6.9.jar,scodec-core_2.12-1.10.3.jar,scodec-bits_2.12-1.1.4.jar,antlr4-runtime-4.8.jar
 
 Setting default log level to "WARN".
 To adjust logging level use sc.setLogLevel(newLevel). For SparkR, use setLogLevel(newLevel).
@@ -319,7 +319,7 @@ The fat jar will have '-bundle' suffix. You can also download pre-built bundles 
 
 Then, run `spark-shell` or `spark-submit` adding the fat jar as the option.
 ```sh
-$ spark-shell --jars spark-cobol_2.12_3.3.2-2.6.9-SNAPSHOT-bundle.jar
+$ spark-shell --jars spark-cobol_2.12_3.3.2-2.6.10-SNAPSHOT-bundle.jar
 ```
 
 > <b>A note for building and running tests on Windows</b>
@@ -1643,7 +1643,7 @@ at org.apache.hadoop.io.nativeio.NativeIO$POSIX.getStat(NativeIO.java:608)
 A: Update hadoop dll to version 3.2.2 or newer.
 
 ## Changelog
-- #### 2.6.8 released 16 October 2023.
+- #### 2.6.9 released 16 October 2023.
    - [#634](https://github.com/AbsaOSS/cobrix/issues/634) Retain metadata when flattening the schema in SparkUtils.
    - [#644](https://github.com/AbsaOSS/cobrix/issues/644) Add support for Spark 3.5.0.
 

--- a/cobol-converters/pom.xml
+++ b/cobol-converters/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>za.co.absa.cobrix</groupId>
         <artifactId>cobrix_2.12</artifactId>
-        <version>2.6.9-SNAPSHOT</version>
+        <version>2.6.10-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/cobol-parser/pom.xml
+++ b/cobol-parser/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>za.co.absa.cobrix</groupId>
         <artifactId>cobrix_2.12</artifactId>
-        <version>2.6.9-SNAPSHOT</version>
+        <version>2.6.10-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/examples/examples-collection/pom.xml
+++ b/examples/examples-collection/pom.xml
@@ -31,7 +31,7 @@
 		<scala.compat.version>2.11</scala.compat.version>	
 		<spark.version>2.4.8</spark.version>
 		<specs.version>2.4.16</specs.version>
-		<spark.cobol.version>2.6.8</spark.cobol.version>
+		<spark.cobol.version>2.6.9</spark.cobol.version>
 	</properties>
 	
 	<dependencies>

--- a/examples/spark-cobol-app/build.sbt
+++ b/examples/spark-cobol-app/build.sbt
@@ -20,7 +20,7 @@ ThisBuild / version      := "0.1.0-SNAPSHOT"
 ThisBuild / scalaVersion := "2.12.17"
 
 val sparkVersion = "3.3.2"
-val sparkCobolVersion = "2.6.8"
+val sparkCobolVersion = "2.6.9"
 val scalatestVersion = "3.2.14"
 
 ThisBuild / libraryDependencies ++= Seq(

--- a/examples/spark-cobol-app/pom.xml
+++ b/examples/spark-cobol-app/pom.xml
@@ -31,7 +31,7 @@
 		<scala.compat.version>2.12</scala.compat.version>
 		<scalatest.version>3.2.14</scalatest.version>
 		<spark.version>3.3.2</spark.version>
-		<spark.cobol.version>2.6.8</spark.cobol.version>
+		<spark.cobol.version>2.6.9</spark.cobol.version>
 	</properties>
 	
 	<dependencies>

--- a/examples/spark-cobol-s3-standalone/pom.xml
+++ b/examples/spark-cobol-s3-standalone/pom.xml
@@ -32,7 +32,7 @@
         <scala.compat.version>2.11</scala.compat.version>
         <scalatest.version>3.2.3</scalatest.version>
         <spark.version>2.4.8</spark.version>
-        <spark.cobol.version>2.6.8</spark.cobol.version>
+        <spark.cobol.version>2.6.9</spark.cobol.version>
         <hadoop.version>3.2.4</hadoop.version>
     </properties>
 

--- a/examples/spark-cobol-s3/pom.xml
+++ b/examples/spark-cobol-s3/pom.xml
@@ -32,7 +32,7 @@
         <scala.compat.version>2.11</scala.compat.version>
         <scalatest.version>3.2.14</scalatest.version>
         <spark.version>2.4.8</spark.version>
-        <spark.cobol.version>2.6.8</spark.cobol.version>
+        <spark.cobol.version>2.6.9</spark.cobol.version>
     </properties>
 
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <groupId>za.co.absa.cobrix</groupId>
     <artifactId>cobrix_2.12</artifactId>
 
-    <version>2.6.9-SNAPSHOT</version>
+    <version>2.6.10-SNAPSHOT</version>
 
     <packaging>pom</packaging>
 

--- a/spark-cobol/pom.xml
+++ b/spark-cobol/pom.xml
@@ -22,7 +22,7 @@
 	<parent>
 		<groupId>za.co.absa.cobrix</groupId>
 		<artifactId>cobrix_2.12</artifactId>
-		<version>2.6.9-SNAPSHOT</version>
+		<version>2.6.10-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "2.6.9"
+ThisBuild / version := "2.6.10-SNAPSHOT"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "2.6.9-SNAPSHOT"
+ThisBuild / version := "2.6.9"


### PR DESCRIPTION
## What's Changed
* #634 Retain metadata on schema flattening in https://github.com/AbsaOSS/cobrix/pull/635
* #644 Add support for Spark 3.5.0 in https://github.com/AbsaOSS/cobrix/pull/645