### PR TITLE
#680 Shade ANTLR for cobol-parser so that it won't clash with Spark's ANTLR runtime.

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -72,7 +72,7 @@ object Dependencies {
 
   val CobolParserDependencies: Seq[ModuleID] = Seq(
     // compile
-    "org.scodec"   %% "scodec-core"    % scodecCoreVersion,
+    "org.scodec"   %% "scodec-core"    % scodecCoreVersion excludeAll(ExclusionRule(organization = "org.scala-lang")),
     "org.antlr"     % "antlr4-runtime" % antlrValue,
     "org.slf4j"     % "slf4j-api"      % slf4jVersion,
 
@@ -80,6 +80,10 @@ object Dependencies {
     "org.scalatest" %% "scalatest"      % scalatestVersion % Test,
     "org.mockito"    % "mockito-core"   % mockitoVersion   % Test,
     "org.slf4j"      % "slf4j-simple"   % slf4jVersion     % Test
+  )
+
+  val CobolParserShadedDependencies: Set[ModuleID] = Set(
+    "org.antlr"      % "antlr4-runtime" % slf4jVersion
   )
 
   val CobolConvertersDependencies: Seq[ModuleID] = Seq(

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -3,6 +3,7 @@ addSbtPlugin("com.github.sbt"    % "sbt-release"   % "1.1.0")
 addSbtPlugin("org.scoverage"     % "sbt-scoverage" % "1.6.0")
 addSbtPlugin("de.heikoseeberger" % "sbt-header"    % "5.2.0")
 addSbtPlugin("com.eed3si9n"      % "sbt-assembly"  % "0.15.0")
+addSbtPlugin("io.get-coursier"   % "sbt-shading"   % "2.1.5")
 
 // sbt-jacoco - workaround related dependencies required to download
 lazy val ow2Version = "9.5"


### PR DESCRIPTION
Closes #680

Also, the shading of dependent libraries is improved for 'sbt assembly'.