### PR TITLE
#728 Add CP1145 code page (Spain and Latin America)

### DIFF
--- a/.github/workflows/jacoco_check.yml
+++ b/.github/workflows/jacoco_check.yml
@@ -28,7 +28,7 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         # The project supports Scala 2.11, 2.12, 2.13

--- a/README.md
+++ b/README.md
@@ -1642,6 +1642,7 @@ The output looks like this:
 | .option("ebcdic_code_page", "cp1047") | EBCDIC 1047 | A code page containing all of the Latin-1/Open System characters.                                           |
 | .option("ebcdic_code_page", "cp1140") | EBCDIC 1140 | Same as code page 037 with € at the position of the international currency symbol ¤.                        |
 | .option("ebcdic_code_page", "cp1141") | EBCDIC 1141 | Same as code page 273 with € at the position of the international currency symbol ¤.                        |
+| .option("ebcdic_code_page", "cp1145") | EBCDIC 1145 | Same as code page 284 with € at the position of the international currency symbol ¤.                        |
 | .option("ebcdic_code_page", "cp1148") | EBCDIC 1148 | Same as code page 500 with € at the position of the international currency symbol ¤.                        |
 | .option("ebcdic_code_page", "cp1364") | EBCDIC 1364 | Double-byte code page CCSID-1364, Korean.                                                                   |
 | .option("ebcdic_code_page", "cp1388") | EBCDIC 1388 | Double-byte code page CCSID-1388, Simplified Chinese.                                                       |

--- a/cobol-parser/src/main/scala/za/co/absa/cobrix/cobol/parser/encoding/codepage/CodePage.scala
+++ b/cobol-parser/src/main/scala/za/co/absa/cobrix/cobol/parser/encoding/codepage/CodePage.scala
@@ -62,6 +62,7 @@ object CodePage extends Logging {
       case "cp1047"          => new CodePage1047
       case "cp1140"          => new CodePage1140
       case "cp1141"          => new CodePage1141
+      case "cp1145"          => new CodePage1145
       case "cp1148"          => new CodePage1148
       case "cp1364"          => new CodePage1364
       case "cp1388"          => new CodePage1388

--- a/cobol-parser/src/main/scala/za/co/absa/cobrix/cobol/parser/encoding/codepage/CodePage1145.scala
+++ b/cobol-parser/src/main/scala/za/co/absa/cobrix/cobol/parser/encoding/codepage/CodePage1145.scala
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2018 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.cobrix.cobol.parser.encoding.codepage
+
+/**
+  * EBCDIC code page 284 is used to represent characters of Spain and Latin America.
+  */
+class CodePage1145 extends SingleByteCodePage(CodePage1145.ebcdicToAsciiMapping) {
+  override def codePageShortName: String = "cp1145"
+}
+
+object CodePage1145 {
+  val ebcdicToAsciiMapping: Array[Char] = {
+    import EbcdicNonPrintable._
+
+    /* This is the EBCDIC Code Page 1145 which is the euro currency update of code  page CCSID 284
+       from https://en.wikibooks.org/wiki/Character_Encodings/Code_Tables/EBCDIC/EBCDIC_284 */
+    val ebcdic2ascii: Array[Char] = {
+      // Non-printable characters map used: http://www.pacsys.com/asciitab.htm
+      Array[Char](
+        c00, c01, c02, c03, spc, c09, spc, del, spc, spc, spc, c0b, c0c, ccr, c0e, c0f, //   0 -  15
+        c10, c11, c12, c13, spc, nel, c08, spc, c18, c19, spc, spc, c1c, c1d, c1e, c1f, //  16 -  31
+        spc, spc, spc, spc, spc, clf, c17, c1b, spc, spc, spc, spc, spc, c05, c06, c07, //  32 -  47
+        spc, spc, c16, spc, spc, spc, spc, c04, spc, spc, spc, spc, c14, c15, spc, c1a, //  48 -  63
+        ' ', rsp, 'â', 'ä', 'à', 'á', 'ã', 'å', 'ç', '¦', '[', '.', '<', '(', '+', '|', //  64 -  79
+        '&', 'é', 'ê', 'ë', 'è', 'í', 'î', 'ï', 'ì', 'ß', ']', '$', '*', ')', ';', '¬', //  80 -  95
+        '-', '/', 'Â', 'Ä', 'À', 'Á', 'Ã', 'Å', 'Ç', '#', 'ñ', ',', '%', '_', '>', '?', //  96 - 111
+        'ø', 'É', 'Ê', 'Ë', 'È', 'Í', 'Î', 'Ï', 'Ì', '`', ':', 'Ñ', '@', qts, '=', qtd, // 112 - 127
+        'Ø', 'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', '«', '»', 'ð', 'ý', 'þ', '±', // 128 - 143
+        '°', 'j', 'k', 'l', 'm', 'n', 'o', 'p', 'q', 'r', 'ª', 'º', 'æ', '¸', 'Æ', '€', // 144 - 159
+        'µ', '¨', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z', '¡', '¿', 'Ð', 'Ý', 'Þ', '®', // 160 - 175
+        '¢', '£', '¥', '·', '©', '§', '¶', '¼', '½', '¾', '^', '!', '¯', '~', '´', '×', // 176 - 191
+        '{', 'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', shy, 'ô', 'ö', 'ò', 'ó', 'õ', // 192 - 207
+        '}', 'J', 'K', 'L', 'M', 'N', 'O', 'P', 'Q', 'R', '¹', 'û', 'ü', 'ù', 'ú', 'ÿ', // 208 - 223
+        bsh, '÷', 'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z', '²', 'Ô', 'Ö', 'Ò', 'Ó', 'Õ', // 224 - 239
+        '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '³', 'Û', 'Ü', 'Ù', 'Ú', spc) // 240 - 255
+    }
+    ebcdic2ascii
+  }
+}

--- a/cobol-parser/src/test/scala/za/co/absa/cobrix/cobol/parser/decoders/StringDecodersSpec.scala
+++ b/cobol-parser/src/test/scala/za/co/absa/cobrix/cobol/parser/decoders/StringDecodersSpec.scala
@@ -18,6 +18,7 @@ package za.co.absa.cobrix.cobol.parser.decoders
 
 import java.nio.charset.StandardCharsets
 import org.scalatest.wordspec.AnyWordSpec
+import za.co.absa.cobrix.cobol.parser.encoding.codepage
 import za.co.absa.cobrix.cobol.parser.encoding.codepage._
 
 class StringDecodersSpec extends AnyWordSpec {
@@ -269,6 +270,17 @@ class StringDecodersSpec extends AnyWordSpec {
         ).map(_.toByte)
 
         val actual = decodeEbcdicString(bytes, KeepAll, new CodePage1141, improvedNullDetection = false)
+
+        assert(actual == expected)
+      }
+
+      "decode a CP1145 string special characters" in {
+        val expected = " äÑ|üÜ¬§ñ]ß¢[Ö{}æö¨å@ÆØÅÄÉ€ "
+        val bytes = Array(0x40, 0x43, 0x7B, 0x4F, 0xDC, 0xFC, 0x5F, 0xB5, 0x6A, 0x5A, 0x59,
+          0xB0, 0x4A, 0xEC, 0xC0, 0xD0, 0x9C, 0xCC, 0xA1, 0x47, 0x7C, 0x9E, 0x80, 0x67, 0x63,
+          0x71, 0x9F, 0x40).map(_.toByte)
+
+        val actual = decodeEbcdicString(bytes, KeepAll, new CodePage1145, improvedNullDetection = false)
 
         assert(actual == expected)
       }

--- a/cobol-parser/src/test/scala/za/co/absa/cobrix/cobol/parser/encoding/codepage/CodePageSingleByteSpec.scala
+++ b/cobol-parser/src/test/scala/za/co/absa/cobrix/cobol/parser/encoding/codepage/CodePageSingleByteSpec.scala
@@ -127,6 +127,11 @@ class CodePageSingleByteSpec extends AnyFunSuite {
     assert(codePage.codePageShortName == "cp1141")
   }
 
+  test("Ensure codepage 'cp1145' gives the associated CodePage") {
+    val codePage = CodePage.getCodePageByName("cp1145")
+    assert(codePage.codePageShortName == "cp1145")
+  }
+
   test("Ensure codepage 'cp1148' gives the associated CodePage") {
     val codePage = CodePage.getCodePageByName("cp1148")
     assert(codePage.codePageShortName == "cp1148")


### PR DESCRIPTION
which is same as CP284 with € at the position of the international currency symbol ¤.

Closes #728 