### PR TITLE
#763 Implement relaxed type restrictions on which field can be used for record length.

### DIFF
--- a/cobol-parser/src/main/scala/za/co/absa/cobrix/cobol/parser/asttransform/DependencyMarker.scala
+++ b/cobol-parser/src/main/scala/za/co/absa/cobrix/cobol/parser/asttransform/DependencyMarker.scala
@@ -18,7 +18,7 @@ package za.co.absa.cobrix.cobol.parser.asttransform
 
 import org.slf4j.LoggerFactory
 import za.co.absa.cobrix.cobol.parser.CopybookParser.CopybookAST
-import za.co.absa.cobrix.cobol.parser.ast.datatype.Integral
+import za.co.absa.cobrix.cobol.parser.ast.datatype.{Decimal, Integral}
 import za.co.absa.cobrix.cobol.parser.ast.{Group, Primitive, Statement}
 
 import scala.collection.mutable
@@ -96,6 +96,7 @@ class DependencyMarker(
             val newPrimitive = if (dependees contains primitive) {
               primitive.dataType match {
                 case _: Integral => true
+                case d: Decimal  if d.scale == 0 => true
                 case dt =>
                   for (stmt <- dependees(primitive)) {
                     if (stmt.dependingOnHandlers.isEmpty)

--- a/cobol-parser/src/main/scala/za/co/absa/cobrix/cobol/reader/validator/ReaderParametersValidator.scala
+++ b/cobol-parser/src/main/scala/za/co/absa/cobrix/cobol/reader/validator/ReaderParametersValidator.scala
@@ -16,6 +16,7 @@
 
 package za.co.absa.cobrix.cobol.reader.validator
 
+import org.slf4j.LoggerFactory
 import za.co.absa.cobrix.cobol.parser.Copybook
 import za.co.absa.cobrix.cobol.parser.ast.Primitive
 import za.co.absa.cobrix.cobol.parser.expression.NumberExprEvaluator
@@ -25,6 +26,7 @@ import za.co.absa.cobrix.cobol.reader.parameters.MultisegmentParameters
 import scala.util.Try
 
 object ReaderParametersValidator {
+  private val log = LoggerFactory.getLogger(this.getClass)
 
   def getEitherFieldAndExpression(fieldOrExpressionOpt: Option[String], recordLengthMap: Map[String, Int], cobolSchema: Copybook): (Option[RecordLengthField], Option[RecordLengthExpression]) = {
     fieldOrExpressionOpt match {
@@ -49,7 +51,7 @@ object ReaderParametersValidator {
     val astNode = field match {
       case s: Primitive =>
         if (!s.dataType.isInstanceOf[za.co.absa.cobrix.cobol.parser.ast.datatype.Integral] && recordLengthMap.isEmpty) {
-          throw new IllegalStateException(s"The record length field $recordLengthFieldName must be an integral type or a value mapping must be specified.")
+          log.warn(s"The record length field $recordLengthFieldName is not integral. Runtime exceptions could occur if values can't be parsed as numbers.")
         }
         if (s.occurs.isDefined && s.occurs.get > 1) {
           throw new IllegalStateException(s"The record length field '$recordLengthFieldName' cannot be an array.")

--- a/cobol-parser/src/test/scala/za/co/absa/cobrix/cobol/reader/iterator/VRLRecordReaderSpec.scala
+++ b/cobol-parser/src/test/scala/za/co/absa/cobrix/cobol/reader/iterator/VRLRecordReaderSpec.scala
@@ -200,32 +200,6 @@ class VRLRecordReaderSpec extends AnyWordSpec {
         assert(record2(14) == 0xF8.toByte)
       }
 
-      "throw an exception on a fraction type" in {
-        val copybookWithFieldLength =
-          """       01  RECORD.
-           05  LEN     PIC 9(8)V99.
-           05  N       PIC 9(2).
-           05  A       PIC X(2).
-          """
-
-        val records = Array[Byte](0x00)
-        val streamH = new ByteStreamMock(records)
-        val streamD = new ByteStreamMock(records)
-        val context = RawRecordContext(0, streamH, streamD, CopybookParser.parseSimple(copybookWithFieldLength), null, null, "")
-
-        val readerParameters = ReaderParameters(lengthFieldExpression = Some("LEN"))
-
-        val ex = intercept[IllegalStateException] {
-          getUseCase(
-            copybook = copybookWithFieldLength,
-            records = records,
-            lengthFieldExpression = Some("LEN"),
-            recordExtractor = Some(new FixedWithRecordLengthExprRawRecordExtractor(context, readerParameters)))
-        }
-
-        assert(ex.getMessage == "The record length field LEN must be an integral type or a value mapping must be specified.")
-      }
-
       "the length mapping with default record length" in {
         val copybookWithLenbgthMap =
           """       01  RECORD.

--- a/spark-cobol/src/test/scala/za/co/absa/cobrix/spark/cobol/source/regression/Test26FixLengthWithIdGeneration.scala
+++ b/spark-cobol/src/test/scala/za/co/absa/cobrix/spark/cobol/source/regression/Test26FixLengthWithIdGeneration.scala
@@ -16,6 +16,7 @@
 
 package za.co.absa.cobrix.spark.cobol.source.regression
 
+import org.apache.spark.SparkException
 import org.scalatest.wordspec.AnyWordSpec
 import org.slf4j.{Logger, LoggerFactory}
 import za.co.absa.cobrix.spark.cobol.source.base.{SimpleComparisonBase, SparkTestBase}
@@ -143,7 +144,7 @@ class Test26FixLengthWithIdGeneration extends AnyWordSpec with SparkTestBase wit
 
   "EBCDIC files" should {
     "correctly work with segment id generation option with length field" in {
-      withTempBinFile("fix_length_reg", ".dat", binFileContentsLengthField) { tmpFileName =>
+      withTempBinFile("fix_length_reg1", ".dat", binFileContentsLengthField) { tmpFileName =>
         val df = spark
           .read
           .format("cobol")
@@ -168,7 +169,7 @@ class Test26FixLengthWithIdGeneration extends AnyWordSpec with SparkTestBase wit
     }
 
     "correctly work with segment id generation option with length expression" in {
-      withTempBinFile("fix_length_reg", ".dat", binFileContentsLengthExpr) { tmpFileName =>
+      withTempBinFile("fix_length_reg2", ".dat", binFileContentsLengthExpr) { tmpFileName =>
         val df = spark
           .read
           .format("cobol")
@@ -192,4 +193,87 @@ class Test26FixLengthWithIdGeneration extends AnyWordSpec with SparkTestBase wit
       }
     }
   }
+
+  "correctly work with segment id generation option with length field" in {
+    withTempBinFile("fix_length_reg3", ".dat", binFileContentsLengthField) { tmpFileName =>
+      val df = spark
+        .read
+        .format("cobol")
+        .option("copybook_contents", copybook)
+        .option("record_format", "F")
+        .option("record_length_field", "LEN")
+        .option("strict_integral_precision", "true")
+        .option("segment_field", "IND")
+        .option("segment_id_prefix", "ID")
+        .option("segment_id_level0", "A")
+        .option("segment_id_level1", "_")
+        .option("redefine-segment-id-map:0", "SEGMENT1 => A")
+        .option("redefine-segment-id-map:1", "SEGMENT2 => B")
+        .option("redefine-segment-id-map:2", "SEGMENT3 => C")
+        .option("input_split_records", 1)
+        .option("pedantic", "true")
+        .load(tmpFileName)
+
+      val actual = SparkUtils.convertDataFrameToPrettyJSON(df.drop("LEN").orderBy("Seg_Id0", "Seg_Id1"))
+
+      assertEqualsMultiline(actual, expected)
+    }
+  }
+
+  "work with string values" in {
+    val copybook =
+      """       01  R.
+           05  LEN      PIC X(1).
+           05  FIELD1   PIC X(1).
+      """
+
+    val binFileContentsLengthField: Array[Byte] = Array[Byte](
+      // A1
+      0xF2.toByte, 0xF3.toByte, 0xF3.toByte, 0xF4.toByte
+    ).map(_.toByte)
+
+    withTempBinFile("fix_length_str", ".dat", binFileContentsLengthField) { tmpFileName =>
+      val df = spark
+        .read
+        .format("cobol")
+        .option("copybook_contents", copybook)
+        .option("record_format", "F")
+        .option("record_length_field", "LEN")
+        .option("pedantic", "true")
+        .load(tmpFileName)
+
+      assert(df.count() == 2)
+    }
+  }
+
+  "fail for incorrect string values" in {
+    val copybook =
+      """       01  R.
+           05  LEN      PIC X(1).
+           05  FIELD1   PIC X(1).
+      """
+
+    val binFileContentsLengthField: Array[Byte] = Array[Byte](
+      // A1
+      0xF2.toByte, 0xF3.toByte, 0xC3.toByte, 0xF4.toByte
+    ).map(_.toByte)
+
+    withTempBinFile("fix_length_str", ".dat", binFileContentsLengthField) { tmpFileName =>
+      val df = spark
+        .read
+        .format("cobol")
+        .option("copybook_contents", copybook)
+        .option("record_format", "F")
+        .option("record_length_field", "LEN")
+        .option("pedantic", "true")
+        .load(tmpFileName)
+
+      val ex = intercept[SparkException] {
+        df.count()
+      }
+
+      assert(ex.getCause.getMessage.contains("Record length value of the field LEN must be an integral type, encountered: 'C'"))
+    }
+  }
+
 }


### PR DESCRIPTION
Closes #763

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of decimal data types with zero scale, allowing them to be treated as integral types in record length and dependency logic.
  - Enhanced error reporting for invalid string values in record length fields, providing clearer messages when parsing fails.
  - Replaced certain exceptions with warning logs for non-integral record length fields, improving user feedback.

- **Tests**
  - Added new test cases to cover decimal depending fields, numeric mappings, and string value handling in record length scenarios.
  - Removed a test that previously checked for exceptions with fractional length fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->