### PR TITLE
#776 Add COMP-3 decoders for the EBCDIC writer

### DIFF
--- a/cobol-parser/src/main/scala/za/co/absa/cobrix/cobol/parser/encoding/BCDNumberEncoders.scala
+++ b/cobol-parser/src/main/scala/za/co/absa/cobrix/cobol/parser/encoding/BCDNumberEncoders.scala
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2018 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.cobrix.cobol.parser.encoding
+
+import java.math.RoundingMode
+
+object BCDNumberEncoders {
+  /**
+    * Encode a number as a binary encoded decimal (BCD) aka COMP-3 format to an array of bytes.
+    *
+    * The length of the output array is determined by the formula: (precision + 1) / 2.
+    *
+    * @param number              The number to encode.
+    * @param precision           Total number of digits in the number.
+    * @param scale               A decimal scale if a number is a decimal. Should be greater or equal to zero.
+    * @param scaleFactor         Additional zeros to be added before of after the decimal point.
+    * @param signed              if true, sign nibble is added and negative numbers are supported.
+    * @param mandatorySignNibble If true, the BCD number should contain the sign nibble. Otherwise, the number is
+    *                            considered unsigned, and negative numbers are encoded as null (zero bytes).
+    * @return A BCD representation of the number, array of zero bytes if the data is not properly formatted.
+    */
+  def encodeBCDNumber(number: java.math.BigDecimal,
+                      precision: Int,
+                      scale: Int,
+                      scaleFactor: Int,
+                      signed: Boolean,
+                      mandatorySignNibble: Boolean): Array[Byte] = {
+    if (precision < 1)
+      throw new IllegalArgumentException(s"Invalid BCD precision=$precision, should be greater than zero.")
+
+    val totalDigits = if (mandatorySignNibble) {
+      if (precision % 2 == 0) precision + 2 else precision + 1
+    } else {
+      if (precision % 2 == 0) precision else precision + 1
+    }
+
+    val byteCount = totalDigits / 2
+    val bytes = new Array[Byte](byteCount)
+
+    if (number == null) {
+      return bytes
+    }
+
+    val integralNumberStr = if (scaleFactor - scale == 0)
+      number.setScale(0, RoundingMode.HALF_DOWN).toString
+    else
+      number.movePointLeft(scaleFactor - scale).setScale(0, RoundingMode.HALF_DOWN).toString
+
+    val isNegative = integralNumberStr.startsWith("-")
+    val digitsOnly = integralNumberStr.stripPrefix("-").stripPrefix("+")
+
+    if (isNegative && (!signed || !mandatorySignNibble)) {
+      return bytes
+    }
+
+    val signNibble: Byte =  if (signed) {
+      if (isNegative) 0x0D else 0x0C
+    } else {
+      0x0F
+    }
+
+    if (digitsOnly.length > precision)
+      return bytes
+
+    val padded = if (mandatorySignNibble) {
+      if (digitsOnly.length == totalDigits - 1)
+        digitsOnly + "0"
+      else
+        "0"*(totalDigits - digitsOnly.length - 1) + digitsOnly + "0"
+    } else {
+      if (digitsOnly.length == totalDigits)
+        digitsOnly
+      else
+        "0"*(totalDigits - digitsOnly.length) + digitsOnly
+    }
+
+    var bi = 0
+
+    while (bi < byteCount) {
+      val high = padded.charAt(bi * 2).asDigit
+      val low = padded.charAt(bi * 2 + 1).asDigit
+
+      bytes(bi) = ((high << 4) | low).toByte
+      bi += 1
+    }
+
+    if (mandatorySignNibble) {
+      bytes(byteCount - 1) = ((bytes(byteCount - 1) & 0xF0) | signNibble).toByte
+    }
+
+    bytes
+  }
+
+}

--- a/cobol-parser/src/test/scala/za/co/absa/cobrix/cobol/parser/encoding/BCDNumberEncodersSuite.scala
+++ b/cobol-parser/src/test/scala/za/co/absa/cobrix/cobol/parser/encoding/BCDNumberEncodersSuite.scala
@@ -1,0 +1,201 @@
+/*
+ * Copyright 2018 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.cobrix.cobol.parser.encoding
+
+import org.scalatest.Assertion
+import org.scalatest.wordspec.AnyWordSpec
+
+class BCDNumberEncodersSuite extends AnyWordSpec {
+  "encodeBCDNumber" should {
+    "integral number" when {
+      "encode a number" in  {
+        val expected = Array[Byte](0x12, 0x34, 0x5C)
+        val actual = BCDNumberEncoders.encodeBCDNumber(new java.math.BigDecimal(12345), 5, 0, 0, signed = true, mandatorySignNibble = true)
+
+        checkExpected(actual, expected)
+      }
+
+      "encode a small number" in  {
+        val expected = Array[Byte](0x00, 0x00, 0x5C)
+        val actual = BCDNumberEncoders.encodeBCDNumber(new java.math.BigDecimal(5), 5, 0, 0, signed = true, mandatorySignNibble = true)
+
+        checkExpected(actual, expected)
+      }
+
+      "encode an unsigned number" in  {
+        val expected = Array[Byte](0x12, 0x34, 0x5F)
+        val actual = BCDNumberEncoders.encodeBCDNumber(new java.math.BigDecimal(12345), 5, 0, 0, signed = false, mandatorySignNibble = true)
+
+        checkExpected(actual, expected)
+      }
+
+      "encode a negative number" in  {
+        val expected = Array[Byte](0x12, 0x34, 0x5D)
+        val actual = BCDNumberEncoders.encodeBCDNumber(new java.math.BigDecimal(-12345), 5, 0, 0, signed = true, mandatorySignNibble = true)
+
+        checkExpected(actual, expected)
+      }
+
+      "encode a small negative number" in  {
+        val expected = Array[Byte](0x00, 0x00, 0x7D)
+        val actual = BCDNumberEncoders.encodeBCDNumber(new java.math.BigDecimal(-7), 4, 0, 0, signed = true, mandatorySignNibble = true)
+
+        checkExpected(actual, expected)
+      }
+
+      "encode a number without sign nibble" in  {
+        val expected = Array[Byte](0x01, 0x23, 0x45)
+        val actual = BCDNumberEncoders.encodeBCDNumber(new java.math.BigDecimal(12345), 5, 0, 0, signed = false, mandatorySignNibble = false)
+
+        checkExpected(actual, expected)
+      }
+
+      "encode a too big number" in  {
+        val expected = Array[Byte](0x00, 0x00, 0x00)
+        val actual = BCDNumberEncoders.encodeBCDNumber(new java.math.BigDecimal(123456), 5, 0, 0, signed = false, mandatorySignNibble = false)
+
+        checkExpected(actual, expected)
+      }
+
+      "encode a too big negative number" in  {
+        val expected = Array[Byte](0x00, 0x00, 0x00)
+        val actual = BCDNumberEncoders.encodeBCDNumber(new java.math.BigDecimal(-123456), 5, 0, 0, signed = true, mandatorySignNibble = true)
+
+        checkExpected(actual, expected)
+      }
+
+      "attempt to encode a negative number without sign nibble" in  {
+        val expected = Array[Byte](0x00, 0x00, 0x00)
+        val actual = BCDNumberEncoders.encodeBCDNumber(new java.math.BigDecimal(-12345), 5, 0, 0, signed = false, mandatorySignNibble = false)
+
+        checkExpected(actual, expected)
+      }
+
+      "attempt to encode a signed number without a sign nibble" in  {
+        val expected = Array[Byte](0x00, 0x00, 0x00)
+        val actual = BCDNumberEncoders.encodeBCDNumber(new java.math.BigDecimal(-12345), 5, 0, 0, signed = true, mandatorySignNibble = false)
+
+        checkExpected(actual, expected)
+      }
+
+      "attempt to encode a number with an incorrect precision" in  {
+        val expected = Array[Byte](0x00, 0x00)
+        val actual = BCDNumberEncoders.encodeBCDNumber(new java.math.BigDecimal(12345), 4, 0, 0, signed = false, mandatorySignNibble = false)
+
+        checkExpected(actual, expected)
+      }
+
+      "attempt to encode a number with an incorrect precision with sign nibble" in  {
+        val expected = Array[Byte](0x00, 0x00, 0x00)
+        val actual = BCDNumberEncoders.encodeBCDNumber(new java.math.BigDecimal(12345), 4, 0, 0, signed = true, mandatorySignNibble = true)
+
+        checkExpected(actual, expected)
+      }
+    }
+
+    "decimal number" when {
+      "encode a number" in  {
+        val expected = Array[Byte](0x12, 0x34, 0x5C)
+        val actual = BCDNumberEncoders.encodeBCDNumber(new java.math.BigDecimal(123.45), 5, 2, 0, signed = true, mandatorySignNibble = true)
+
+        checkExpected(actual, expected)
+      }
+
+      "encode a small number" in  {
+        val expected = Array[Byte](0x00, 0x00, 0x5C)
+        val actual = BCDNumberEncoders.encodeBCDNumber(new java.math.BigDecimal(0.05), 5, 2, 0, signed = true, mandatorySignNibble = true)
+
+        checkExpected(actual, expected)
+      }
+
+      "encode an unsigned number" in  {
+        val expected = Array[Byte](0x12, 0x34, 0x5F)
+        val actual = BCDNumberEncoders.encodeBCDNumber(new java.math.BigDecimal(1234.5), 5, 1, 0, signed = false, mandatorySignNibble = true)
+
+        checkExpected(actual, expected)
+      }
+
+      "encode a negative number" in  {
+        val expected = Array[Byte](0x12, 0x34, 0x5D)
+        val actual = BCDNumberEncoders.encodeBCDNumber(new java.math.BigDecimal(-12.345), 5, 3, 0, signed = true, mandatorySignNibble = true)
+
+        checkExpected(actual, expected)
+      }
+
+      "encode a small negative number" in  {
+        val expected = Array[Byte](0x00, 0x00, 0x7D)
+        val actual = BCDNumberEncoders.encodeBCDNumber(new java.math.BigDecimal(-0.00007), 4, 5, 0, signed = true, mandatorySignNibble = true)
+
+        checkExpected(actual, expected)
+      }
+
+      "encode a number without sign nibble" in  {
+        val expected = Array[Byte](0x01, 0x23, 0x45)
+        val actual = BCDNumberEncoders.encodeBCDNumber(new java.math.BigDecimal(123.45), 5, 2, 0, signed = false, mandatorySignNibble = false)
+
+        checkExpected(actual, expected)
+      }
+
+      "encode a too precise number" in  {
+        val expected = Array[Byte](0x01, 0x23, 0x46)
+        val actual = BCDNumberEncoders.encodeBCDNumber(new java.math.BigDecimal(123.456), 5, 2, 0, signed = false, mandatorySignNibble = false)
+
+        checkExpected(actual, expected)
+      }
+
+      "encode a too big number" in  {
+        val expected = Array[Byte](0x00, 0x00, 0x00)
+        val actual = BCDNumberEncoders.encodeBCDNumber(new java.math.BigDecimal(1234.56), 5, 2, 0, signed = false, mandatorySignNibble = false)
+
+        checkExpected(actual, expected)
+      }
+
+      "encode a too big negative number" in  {
+        val expected = Array[Byte](0x00, 0x00, 0x00)
+        val actual = BCDNumberEncoders.encodeBCDNumber(new java.math.BigDecimal(-1234.56), 5, 2, 0, signed = true, mandatorySignNibble = true)
+
+        checkExpected(actual, expected)
+      }
+
+      "encode a number with positive scale factor" in  {
+        val expected = Array[Byte](0x00, 0x12, 0x3F)
+        val actual = BCDNumberEncoders.encodeBCDNumber(new java.math.BigDecimal(12300), 5, 0, 2, signed = false, mandatorySignNibble = true)
+
+        checkExpected(actual, expected)
+      }
+
+      "encode a number with negative scale factor" in  {
+        val expected = Array[Byte](0x00, 0x12, 0x3F)
+        val actual = BCDNumberEncoders.encodeBCDNumber(new java.math.BigDecimal(1.23), 5, 0, -2, signed = false, mandatorySignNibble = true)
+
+        checkExpected(actual, expected)
+      }
+    }
+  }
+
+  def checkExpected(actual: Array[Byte], expected: Array[Byte]): Assertion = {
+    if (!actual.sameElements(expected)) {
+      val actualHex = actual.map(b => f"$b%02X").mkString(" ")
+      val expectedHex = expected.map(b => f"$b%02X").mkString(" ")
+      fail(s"Actual: $actualHex\nExpected: $expectedHex")
+    } else {
+      succeed
+    }
+  }
+
+
+}

--- a/cobol-parser/src/test/scala/za/co/absa/cobrix/cobol/parser/encoding/BCDNumberEncodersSuite.scala
+++ b/cobol-parser/src/test/scala/za/co/absa/cobrix/cobol/parser/encoding/BCDNumberEncodersSuite.scala
@@ -29,6 +29,13 @@ class BCDNumberEncodersSuite extends AnyWordSpec {
         checkExpected(actual, expected)
       }
 
+      "encode a number with an even precision" in  {
+        val expected = Array[Byte](0x01, 0x23, 0x4C)
+        val actual = BCDNumberEncoders.encodeBCDNumber(new java.math.BigDecimal(1234), 4, 0, 0, signed = true, mandatorySignNibble = true)
+
+        checkExpected(actual, expected)
+      }
+
       "encode a small number" in  {
         val expected = Array[Byte](0x00, 0x00, 0x5C)
         val actual = BCDNumberEncoders.encodeBCDNumber(new java.math.BigDecimal(5), 5, 0, 0, signed = true, mandatorySignNibble = true)
@@ -64,6 +71,13 @@ class BCDNumberEncodersSuite extends AnyWordSpec {
         checkExpected(actual, expected)
       }
 
+      "encode a number without sign nibble with an even precision" in  {
+        val expected = Array[Byte](0x12, 0x34)
+        val actual = BCDNumberEncoders.encodeBCDNumber(new java.math.BigDecimal(1234), 4, 0, 0, signed = true, mandatorySignNibble = false)
+
+        checkExpected(actual, expected)
+      }
+
       "encode a too big number" in  {
         val expected = Array[Byte](0x00, 0x00, 0x00)
         val actual = BCDNumberEncoders.encodeBCDNumber(new java.math.BigDecimal(123456), 5, 0, 0, signed = false, mandatorySignNibble = false)
@@ -74,6 +88,13 @@ class BCDNumberEncodersSuite extends AnyWordSpec {
       "encode a too big negative number" in  {
         val expected = Array[Byte](0x00, 0x00, 0x00)
         val actual = BCDNumberEncoders.encodeBCDNumber(new java.math.BigDecimal(-123456), 5, 0, 0, signed = true, mandatorySignNibble = true)
+
+        checkExpected(actual, expected)
+      }
+
+      "encode a number with nbegative scale" in  {
+        val expected = Array[Byte](0x00, 0x00, 0x00)
+        val actual = BCDNumberEncoders.encodeBCDNumber(new java.math.BigDecimal(12345), 5, -1, 0, signed = false, mandatorySignNibble = false)
 
         checkExpected(actual, expected)
       }
@@ -104,6 +125,10 @@ class BCDNumberEncodersSuite extends AnyWordSpec {
         val actual = BCDNumberEncoders.encodeBCDNumber(new java.math.BigDecimal(12345), 4, 0, 0, signed = true, mandatorySignNibble = true)
 
         checkExpected(actual, expected)
+      }
+
+      "attempt to encode a number with zero prexision" in  {
+        assertThrows[IllegalArgumentException](BCDNumberEncoders.encodeBCDNumber(new java.math.BigDecimal(12345), 0, 0, 0, signed = true, mandatorySignNibble = true))
       }
     }
 

--- a/cobol-parser/src/test/scala/za/co/absa/cobrix/cobol/parser/extract/BinaryExtractorSpec.scala
+++ b/cobol-parser/src/test/scala/za/co/absa/cobrix/cobol/parser/extract/BinaryExtractorSpec.scala
@@ -216,7 +216,7 @@ class BinaryExtractorSpec extends AnyFunSuite {
     val fieldName2: String = "COMPANY.COMPANY-ID-NUM"
     val fields2 = copybook.getFieldByName(fieldName2)
     assert(fields2.isInstanceOf[Primitive])
-    assert(fields2.asInstanceOf[Primitive].encode.isEmpty)
+    assert(fields2.asInstanceOf[Primitive].encode.nonEmpty)
   }
 
   test("Test padding when setting field value by name") {
@@ -230,7 +230,7 @@ class BinaryExtractorSpec extends AnyFunSuite {
     val fieldName2: String = "COMPANY.COMPANY-ID-NUM"
     val fields2 = copybook2.getFieldByName(fieldName2)
     assert(fields2.isInstanceOf[Primitive])
-    assert(fields2.asInstanceOf[Primitive].encode.isEmpty)
+    assert(fields2.asInstanceOf[Primitive].encode.nonEmpty)
   }
 
   test("Test truncating when setting field value by name") {
@@ -244,6 +244,6 @@ class BinaryExtractorSpec extends AnyFunSuite {
     val fieldName2: String = "COMPANY.COMPANY-ID-NUM"
     val fields2 = copybook2.getFieldByName(fieldName2)
     assert(fields2.isInstanceOf[Primitive])
-    assert(fields2.asInstanceOf[Primitive].encode.isEmpty)
+    assert(fields2.asInstanceOf[Primitive].encode.nonEmpty)
   }
 }

--- a/spark-cobol/src/main/scala/za/co/absa/cobrix/spark/cobol/writer/BasicRecordCombiner.scala
+++ b/spark-cobol/src/main/scala/za/co/absa/cobrix/spark/cobol/writer/BasicRecordCombiner.scala
@@ -19,12 +19,10 @@ package za.co.absa.cobrix.spark.cobol.writer
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.DataFrame
 import za.co.absa.cobrix.cobol.parser.Copybook
+import za.co.absa.cobrix.cobol.parser.ast.datatype.{Decimal, Integral}
 import za.co.absa.cobrix.cobol.parser.ast.{Group, Primitive, Statement}
 import za.co.absa.cobrix.cobol.reader.parameters.ReaderParameters
 import za.co.absa.cobrix.cobol.reader.schema.CobolSchema
-import za.co.absa.cobrix.cobol.parser.ast.datatype.{AlphaNumeric, COMP3, COMP3U, CobolType, Decimal, Integral}
-
-import java.io.{ByteArrayOutputStream, ObjectOutputStream}
 
 class BasicRecordCombiner extends RecordCombiner {
 
@@ -34,8 +32,8 @@ class BasicRecordCombiner extends RecordCombiner {
     val ast = getAst(cobolSchema)
     val copybookFields = ast.children.filter {
       case p: Primitive => !p.isFiller
-      case g: Group => !g.isFiller
-      case _ => true
+      case g: Group     => !g.isFiller
+      case _            => true
     }
 
     validateSchema(df, copybookFields.toSeq)
@@ -123,8 +121,8 @@ object BasicRecordCombiner {
 
     val usage = field.dataType match {
       case dt: Integral => dt.compact.map(_.toString).getOrElse("USAGE IS DISPLAY")
-      case dt: Decimal => dt.compact.map(_.toString).getOrElse("USAGE IS DISPLAY")
-      case _ => ""
+      case dt: Decimal  => dt.compact.map(_.toString).getOrElse("USAGE IS DISPLAY")
+      case _            => ""
     }
 
     s"$pic $usage".trim

--- a/spark-cobol/src/test/scala/za/co/absa/cobrix/spark/cobol/writer/FixedLengthEbcdicWriterSuite.scala
+++ b/spark-cobol/src/test/scala/za/co/absa/cobrix/spark/cobol/writer/FixedLengthEbcdicWriterSuite.scala
@@ -126,6 +126,64 @@ class FixedLengthEbcdicWriterSuite extends AnyWordSpec with SparkTestBase with B
       }
     }
 
+    "write data frames with COMP-3 fields" in {
+      withTempDirectory("cobol_writer1") { tempDir =>
+        val df = List(
+          (1, 100.5, new java.math.BigDecimal(10.23), 1, 100.5, new java.math.BigDecimal(10.12)),
+          (2, 800.4, new java.math.BigDecimal(30), 2, 800.4, new java.math.BigDecimal(30)),
+          (3, 22.33, new java.math.BigDecimal(-20), 3, 22.33, new java.math.BigDecimal(-20))
+        ).toDF("A", "B", "C", "D", "E", "F")
+
+        val path = new Path(tempDir, "writer1")
+
+        val copybookContentsWithFilers =
+          """       01  RECORD.
+           05  A       PIC S9(1)      COMP-3.
+           05  B       PIC 9(4)V9(2)  COMP-3.
+           05  C       PIC S9(2)V9(2) COMP-3.
+           05  D       PIC 9(1)       COMP-3U.
+           05  E       PIC 9(4)V9(2)  COMP-3U.
+           05  F       PIC 9(2)V9(2)  COMP-3U.
+    """
+
+        df.coalesce(1)
+          .orderBy("A")
+          .write
+          .format("cobol")
+          .mode(SaveMode.Overwrite)
+          .option("copybook_contents", copybookContentsWithFilers)
+          .save(path.toString)
+
+        val fs = path.getFileSystem(spark.sparkContext.hadoopConfiguration)
+
+        assert(fs.exists(path), "Output directory should exist")
+        val files = fs.listStatus(path)
+          .filter(_.getPath.getName.startsWith("part-"))
+        assert(files.nonEmpty, "Output directory should contain part files")
+
+        val partFile = files.head.getPath
+        val data = fs.open(partFile)
+        val bytes = new Array[Byte](files.head.getLen.toInt)
+        data.readFully(bytes)
+        data.close()
+
+        // Expected EBCDIC data for sample test data
+        val expected = Array(
+          0x1C, 0x00, 0x10, 0x05, 0x0F, 0x01, 0x02, 0x3C, 0x01, 0x01, 0x00, 0x50, 0x10, 0x12,
+          0x2C, 0x00, 0x80, 0x04, 0x0F, 0x03, 0x00, 0x0C, 0x02, 0x08, 0x00, 0x40, 0x30, 0x00,
+          0x3C, 0x00, 0x02, 0x23, 0x3F, 0x02, 0x00, 0x0D, 0x03, 0x00, 0x22, 0x33, 0x00, 0x00
+        ).map(_.toByte)
+
+        if (!bytes.sameElements(expected)) {
+          println(s"Expected bytes: ${expected.map("%02X" format _).mkString(" ")}")
+          println(s"Actual bytes:   ${bytes.map("%02X" format _).mkString(" ")}")
+
+          assert(bytes.sameElements(expected), "Written data should match expected EBCDIC encoding")
+        }
+      }
+    }
+
+
     "write should fail with save mode append and the path exists" in {
       withTempDirectory("cobol_writer3") { tempDir =>
         val df = List(("A", "First"), ("B", "Scnd"), ("C", "Last")).toDF("A", "B")


### PR DESCRIPTION
Closes #776 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added packed decimal (COMP-3/COMP-3U) encoding for numeric fields with sign, precision, scale handling.
  * Encoder selector now exposes a packed-decimal encoder option.

* **Refactor**
  * Centralized low-level field-setting and a helper to derive PIC/usage for clearer error messages.

* **Tests**
  * New unit tests for packed-decimal encoding (many edge cases).
  * Updated extractor expectations and an integration test asserting byte-accurate EBCDIC output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->