### PR TITLE
#784 Switch to new Sonatype deployment

### DIFF
--- a/.github/workflows/release2.yaml
+++ b/.github/workflows/release2.yaml
@@ -1,0 +1,44 @@
+#
+# Copyright 2022 ABSA Group Limited
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name: Release2
+
+on:
+  workflow_dispatch:
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  publish:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-java@v4.2.1
+        with:
+          distribution: temurin
+          java-version: 8
+          cache: sbt
+      - name: Build and release to Sonatype and Maven Central
+        run: sbt ci-release
+        env:
+          PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
+          PGP_SECRET: ${{ secrets.PGP_SECRET }}
+          SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
+          SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}

--- a/build.sbt
+++ b/build.sbt
@@ -52,9 +52,11 @@ lazy val cobrix = (project in file("."))
   .disablePlugins(sbtassembly.AssemblyPlugin)
   .settings(
     name := "cobrix",
+    crossScalaVersions := List(scala211, scala212, scala213),
 
     // No need to publish the aggregation [empty] artifact
     publishArtifact := false,
+    publish / skip := true,
     publish := {},
     publishLocal := {}
   )
@@ -65,13 +67,13 @@ lazy val cobolParser = (project in file("cobol-parser"))
   .enablePlugins(AutomateHeaderPlugin)
   .settings(
     name := "cobol-parser",
+    crossScalaVersions := List(scala211, scala212, scala213),
     libraryDependencies ++= CobolParserDependencies :+ getScalaDependency(scalaVersion.value),
     shadedDependencies ++= CobolParserShadedDependencies,
     shadingRules ++= Seq (
       ShadingRule.moveUnder("org.antlr.v4.runtime", "za.co.absa.cobrix.cobol.parser.shaded")
     ),
     validNamespaces ++= Set("za"),
-    releasePublishArtifactsAction := PgpKeys.publishSigned.value,
     assemblySettings,
     jacocoReportSettings := commonJacocoReportSettings.withTitle("cobrix:cobol-parser Jacoco Report"),
     jacocoExcludes := commonJacocoExcludes
@@ -83,9 +85,11 @@ lazy val cobolConverters = (project in file("cobol-converters"))
   .enablePlugins(AutomateHeaderPlugin)
   .settings(
     name := "cobol-converters",
+    crossScalaVersions := List(scala211, scala212, scala213),
     libraryDependencies ++= CobolConvertersDependencies :+ getScalaDependency(scalaVersion.value),
     // No need to publish this artifact since it has test only at the moment
     publishArtifact := false,
+    publish / skip := true,
     publish := {},
     publishLocal := {}
   )
@@ -93,6 +97,7 @@ lazy val cobolConverters = (project in file("cobol-converters"))
 lazy val sparkCobol = (project in file("spark-cobol"))
   .settings(
     name := "spark-cobol",
+    crossScalaVersions := List(scala211, scala212, scala213),
     printSparkVersion := {
       val log = streams.value.log
       log.info(s"Building with Spark ${sparkVersion(scalaVersion.value)}, Scala ${scalaVersion.value}")
@@ -111,7 +116,6 @@ lazy val sparkCobol = (project in file("spark-cobol"))
     libraryDependencies ++= SparkCobolDependencies(scalaVersion.value) :+ getScalaDependency(scalaVersion.value),
     Test / fork := true, // Spark tests fail randomly otherwise
     populateBuildInfoTemplate,
-    releasePublishArtifactsAction := PgpKeys.publishSigned.value,
     assemblySettings
   ).dependsOn(cobolParser)
   .settings(
@@ -123,10 +127,6 @@ lazy val sparkCobol = (project in file("spark-cobol"))
 // scoverage settings
 ThisBuild / coverageExcludedPackages := ".*examples.*;.*replication.*"
 ThisBuild / coverageExcludedFiles := ".*Example.*;Test.*"
-
-// release settings
-releaseCrossBuild := true
-addCommandAlias("releaseNow", ";set releaseVersionBump := sbtrelease.Version.Bump.Bugfix; release with-defaults")
 
 lazy val assemblySettings = Seq(
   // This merge strategy retains service entries for all services in manifest.

--- a/build.sbt
+++ b/build.sbt
@@ -109,7 +109,6 @@ lazy val sparkCobol = (project in file("spark-cobol"))
       }
     },
     libraryDependencies ++= SparkCobolDependencies(scalaVersion.value) :+ getScalaDependency(scalaVersion.value),
-    dependencyOverrides ++= SparkCobolDependenciesOverride,
     Test / fork := true, // Spark tests fail randomly otherwise
     populateBuildInfoTemplate,
     releasePublishArtifactsAction := PgpKeys.publishSigned.value,

--- a/pom.xml
+++ b/pom.xml
@@ -102,7 +102,6 @@
         <maven.release.version>2.4.2</maven.release.version>
         <maven.scm.provider.gitexe.version>1.8.1</maven.scm.provider.gitexe.version>
         <maven.scoverage.version>1.3.0</maven.scoverage.version>
-        <maven.rat.plugin.version>0.12</maven.rat.plugin.version>
         <maven.gpg.plugin.version>1.6</maven.gpg.plugin.version>
 
         <!-- Frameworks and libraries -->
@@ -111,7 +110,6 @@
         <spark.version>3.5.6</spark.version>
         <scalatest.version>3.2.19</scalatest.version>
         <specs.version>2.4.16</specs.version>
-        <guava.version>15.0</guava.version>
         <jackson.version>2.13.1</jackson.version>
         <mockito.version>4.11.0</mockito.version>
         <scala_logging.version>3.7.2</scala_logging.version>
@@ -250,11 +248,6 @@
                 <version>${mockito.version}</version>
                 <scope>test</scope>
             </dependency>
-            <dependency>
-                <groupId>com.google.guava</groupId>
-                <artifactId>guava</artifactId>
-                <version>${guava.version}</version>
-            </dependency>
         </dependencies>
     </dependencyManagement>
 
@@ -267,10 +260,6 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>${maven.compiler.version}</version>
-                <configuration>
-                    <source>${maven.compiler.source}</source>
-                    <target>${maven.compiler.target}</target>
-                </configuration>
             </plugin>
             <!-- the Maven Scala plugin -->
             <plugin>

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -17,7 +17,6 @@
 import sbt._
 
 object Dependencies {
-  private val guavaVersion = "15.0"
   private val scodecCoreVersion = "1.11.4"
   private val antlrValue = "4.8"
   private val slf4jVersion = "1.7.25"
@@ -60,13 +59,6 @@ object Dependencies {
     // test
     "org.scalatest"    %% "scalatest"        % scalatestVersion           % Test,
     "org.mockito"       % "mockito-core"     % mockitoVersion             % Test
-  )
-
-  val SparkCobolDependenciesOverride: Seq[ModuleID] = Seq(
-    // Needs to be added as a separate dependency since Spark uses an newer
-    // version of Guava which has removed 'com.google.common.base.Stopwatch.elapsedMillis',
-    // however, the version of Hadoop imported by Spark relies on that method.
-    "com.google.guava" % "guava" % guavaVersion,
   )
 
   val CobolParserDependencies: Seq[ModuleID] = Seq(

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.10.11
+sbt.version=1.11.6

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,9 +1,9 @@
-addSbtPlugin("com.github.sbt"    % "sbt-pgp"       % "2.2.1")
-addSbtPlugin("com.github.sbt"    % "sbt-release"   % "1.1.0")
-addSbtPlugin("org.scoverage"     % "sbt-scoverage" % "1.6.0")
-addSbtPlugin("de.heikoseeberger" % "sbt-header"    % "5.2.0")
-addSbtPlugin("com.eed3si9n"      % "sbt-assembly"  % "0.15.0")
-addSbtPlugin("io.get-coursier"   % "sbt-shading"   % "2.1.5")
+addSbtPlugin("com.github.sbt"    % "sbt-ci-release"    % "1.11.1")
+addSbtPlugin("com.eed3si9n"      % "sbt-projectmatrix" % "0.9.2")
+addSbtPlugin("org.scoverage"     % "sbt-scoverage"     % "1.6.0")
+addSbtPlugin("de.heikoseeberger" % "sbt-header"        % "5.2.0")
+addSbtPlugin("com.eed3si9n"      % "sbt-assembly"      % "0.15.0")
+addSbtPlugin("io.get-coursier"   % "sbt-shading"       % "2.1.5")
 
 addDependencyTreePlugin
 

--- a/publish.sbt
+++ b/publish.sbt
@@ -44,15 +44,4 @@ ThisBuild / description := "COBOL Reading and Import Extensions for Apache Spark
 ThisBuild / startYear := Some(2018)
 ThisBuild / licenses += "Apache-2.0" -> url("https://www.apache.org/licenses/LICENSE-2.0.txt")
 
-ThisBuild / pomIncludeRepository := { _ => false }
-ThisBuild / publishTo := {
-  val nexus = "https://oss.sonatype.org/"
-  if (isSnapshot.value) {
-    Some("snapshots" at s"${nexus}content/repositories/snapshots")
-  } else {
-    Some("releases" at s"${nexus}service/local/staging/deploy/maven2")
-  }
-}
-ThisBuild / publishMavenStyle := true
-
 ThisBuild / versionScheme := Some("semver-spec")

--- a/spark-cobol/pom.xml
+++ b/spark-cobol/pom.xml
@@ -42,15 +42,6 @@
 			<scope>provided</scope>
 		</dependency>
 
-		<!-- guava -->
-		<!-- Needs to be added as a separate dependency since Spark uses an newer 
-			version of Guava which has removed 'com.google.common.base.Stopwatch.elapsedMillis', 
-			however, the version of Hadoop imported by Spark relies on that method. -->
-		<dependency>
-			<groupId>com.google.guava</groupId>
-			<artifactId>guava</artifactId>
-		</dependency>
-
 		<!-- COBOL parser -->
 		<dependency>
 			<groupId>za.co.absa.cobrix</groupId>

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,0 @@
-ThisBuild / version := "2.8.5-SNAPSHOT"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added cross-version artifacts for Scala 2.11, 2.12, and 2.13 across key modules.

* **Chores**
  * Introduced a new release workflow that publishes artifacts to Maven Central.
  * Upgraded build tooling (including sbt 1.11.6 and updated plugins).
  * Simplified dependency management by removing explicit Guava version pinning/overrides.
  * Removed legacy release and publishing configurations to streamline the build.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->