### PR TITLE
#795 Do not create a redundant data stream.

### DIFF
--- a/cobol-parser/src/main/scala/za/co/absa/cobrix/cobol/processor/impl/CobolProcessorInPlace.scala
+++ b/cobol-parser/src/main/scala/za/co/absa/cobrix/cobol/processor/impl/CobolProcessorInPlace.scala
@@ -46,16 +46,15 @@ class CobolProcessorInPlace(readerParameters: ReaderParameters,
                       (rawRecordProcessor: RawRecordProcessor): Long = {
     val recordExtractor = CobolProcessorBase.getRecordExtractor(readerParameters, copybookContents, inputStream, None)
 
-    val dataStream = inputStream.copyStream()
     try {
       StreamProcessor.processStreamInPlace(copybook,
         options,
-        dataStream,
+        inputStream,
         recordExtractor,
         rawRecordProcessor,
         outputStream)
     } finally {
-      dataStream.close()
+      inputStream.close()
     }
   }
 

--- a/spark-cobol/src/main/scala/za/co/absa/cobrix/spark/cobol/SparkCobolProcessor.scala
+++ b/spark-cobol/src/main/scala/za/co/absa/cobrix/spark/cobol/SparkCobolProcessor.scala
@@ -198,6 +198,8 @@ object SparkCobolProcessor {
   private def getCobolParameters(listOfFiles: Seq[String], copybookContents: String, options: Map[String, String], ignoreRedundantOptions: Boolean): CobolParameters = {
     val varLenOptions = options + (PARAM_GENERATE_RECORD_ID -> "true")
 
+    // This method might be called several times during the ebcdic file processing. If there are redundant options, they will be logged.
+    // `ignoreRedundantOptions=true` when the method is called just for copybook parsing so logging redundant options could be skipped.
     CobolParametersParser.parse(new Parameters(varLenOptions), !ignoreRedundantOptions)
       .copy(sourcePaths = listOfFiles, copybookContent = Option(copybookContents))
   }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized stream processing by eliminating unnecessary stream duplication during in-place operations, reducing memory overhead.

* **Documentation**
  * Added clarifying comments documenting internal processing behavior during EBCDIC conversions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->