### PR TITLE
#803 Fix possible cases when Hadoop file streams are opened but not closed.

### DIFF
--- a/cobol-parser/src/main/scala/za/co/absa/cobrix/cobol/reader/VarLenNestedReader.scala
+++ b/cobol-parser/src/main/scala/za/co/absa/cobrix/cobol/reader/VarLenNestedReader.scala
@@ -171,12 +171,17 @@ class VarLenNestedReader[T: ClassTag](copybookContents: Seq[String],
       case None => false
     }
 
+    val recordExtractorOpt = recordExtractor(0L, dataStream, headerStream)
+    if (recordExtractorOpt.isEmpty) {
+      headerStream.close()
+    }
+
     segmentIdField match {
       case Some(field) => IndexGenerator.sparseIndexGenerator(fileNumber,
         dataStream,
         readerProperties.fileStartOffset,
         recordHeaderParser,
-        recordExtractor(0L, dataStream, headerStream),
+        recordExtractorOpt,
         inputSplitSizeRecords,
         inputSplitSizeMB,
         Some(copybook),
@@ -187,7 +192,7 @@ class VarLenNestedReader[T: ClassTag](copybookContents: Seq[String],
         dataStream,
         readerProperties.fileStartOffset,
         recordHeaderParser,
-        recordExtractor(0L, dataStream, headerStream),
+        recordExtractorOpt,
         inputSplitSizeRecords,
         inputSplitSizeMB,
         None,

--- a/spark-cobol/src/main/scala/za/co/absa/cobrix/spark/cobol/reader/VarLenNestedReader.scala
+++ b/spark-cobol/src/main/scala/za/co/absa/cobrix/spark/cobol/reader/VarLenNestedReader.scala
@@ -53,14 +53,19 @@ final class VarLenNestedReader(copybookContents: Seq[String],
                               headerStream: SimpleStream,
                               startingFileOffset: Long,
                               fileNumber: Int,
-                              startingRecordIndex: Long): Iterator[Row] =
+                              startingRecordIndex: Long): Iterator[Row] = {
+    val recordExtractorOpt = recordExtractor(startingRecordIndex, dataStream, headerStream)
+    if (recordExtractorOpt.isEmpty) {
+      headerStream.close()
+    }
+
     if (cobolSchema.copybook.isHierarchical) {
       new RowIterator(
         new VarLenHierarchicalIterator(cobolSchema.copybook,
           dataStream,
           getReaderProperties,
           recordHeaderParser,
-          recordExtractor(startingRecordIndex, dataStream, headerStream),
+          recordExtractorOpt,
           fileNumber,
           startingRecordIndex,
           startingFileOffset,
@@ -72,7 +77,7 @@ final class VarLenNestedReader(copybookContents: Seq[String],
           dataStream,
           getReaderProperties,
           recordHeaderParser,
-          recordExtractor(startingRecordIndex, dataStream, headerStream),
+          recordExtractorOpt,
           fileNumber,
           startingRecordIndex,
           startingFileOffset,
@@ -80,4 +85,5 @@ final class VarLenNestedReader(copybookContents: Seq[String],
           new RowHandler())
       )
     }
+  }
 }

--- a/spark-cobol/src/main/scala/za/co/absa/cobrix/spark/cobol/source/streaming/BufferedFSDataInputStream.scala
+++ b/spark-cobol/src/main/scala/za/co/absa/cobrix/spark/cobol/source/streaming/BufferedFSDataInputStream.scala
@@ -18,6 +18,8 @@ package za.co.absa.cobrix.spark.cobol.source.streaming
 
 import org.apache.hadoop.fs.{FSDataInputStream, FileSystem, Path}
 
+import java.io.IOException
+
 class BufferedFSDataInputStream(filePath: Path, fileSystem: FileSystem, startOffset: Long, bufferSizeInMegabytes: Int, maximumBytes: Long ) {
   val bytesInMegabyte: Int = 1048576
 
@@ -38,6 +40,7 @@ class BufferedFSDataInputStream(filePath: Path, fileSystem: FileSystem, startOff
   private var bufferConitainBytes = 0
   private var bytesRead = 0
 
+  @throws[IOException]
   def close(): Unit = {
     if (!isStreamClosed) {
       in.close()

--- a/spark-cobol/src/test/scala/za/co/absa/cobrix/spark/cobol/source/streaming/FileStreamerSpec.scala
+++ b/spark-cobol/src/test/scala/za/co/absa/cobrix/spark/cobol/source/streaming/FileStreamerSpec.scala
@@ -44,10 +44,16 @@ class FileStreamerSpec extends AnyFlatSpec with BeforeAndAfter with Matchers {
 
   it should "throw if file does not exist" in {
     assertThrows[FileNotFoundException] {
-      new FileStreamer(new File(TEMP_DIR, "inexistent").getAbsolutePath, FileSystem.get(new Configuration()))
+      val stream = new FileStreamer(new File(TEMP_DIR, "inexistent").getAbsolutePath, FileSystem.get(new Configuration()))
+      stream.size
     }
   }
 
+  it should "not throw if the stream is never used, even if the file does not exist" in {
+    noException should be thrownBy {
+      new FileStreamer(new File(TEMP_DIR, "inexistent").getAbsolutePath, FileSystem.get(new Configuration()))
+    }
+  }
   it should "return array of same length than expected number of bytes if enough data" in {
     val batchLength = 8
     val iterations = 10


### PR DESCRIPTION
This is especially related to header streams.

Closes #803

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `size` and `totalSize` properties for file streaming operations.

* **Bug Fixes**
  * Improved resource management with proper stream closure and cleanup.
  * File streams now open lazily on first read instead of during initialization.

* **Tests**
  * Updated test cases to validate lazy file opening behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->