### PR TITLE
#816 Fix the reliance on log4j libraries in the classpath `FileStreamer` by switching logging to slf4j interfaces.

### DIFF
--- a/spark-cobol/src/main/scala/za/co/absa/cobrix/spark/cobol/source/streaming/FileStreamer.scala
+++ b/spark-cobol/src/main/scala/za/co/absa/cobrix/spark/cobol/source/streaming/FileStreamer.scala
@@ -17,8 +17,8 @@
 package za.co.absa.cobrix.spark.cobol.source.streaming
 
 import org.apache.hadoop.conf.Configuration
+import org.slf4j.{Logger, LoggerFactory}
 import org.apache.hadoop.fs.{ContentSummary, Path}
-import org.apache.log4j.Logger
 import za.co.absa.cobrix.cobol.reader.common.Constants
 import za.co.absa.cobrix.cobol.reader.stream.SimpleStream
 import za.co.absa.cobrix.spark.cobol.utils.FileUtils
@@ -39,7 +39,7 @@ import java.io.IOException
   */
 class FileStreamer(filePath: String, hadoopConfig: Configuration, startOffset: Long = 0L, maximumBytes: Long = 0L) extends SimpleStream {
 
-  private val logger = Logger.getLogger(FileStreamer.this.getClass)
+  private val logger: Logger = LoggerFactory.getLogger(this.getClass)
 
   private val hadoopPath = new Path(filePath)
   private var byteIndex = startOffset


### PR DESCRIPTION
Closes #816

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal logging infrastructure for improved compatibility and maintainability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->