### PR TITLE
#851 Make '_corrupt_records' a nullable field.

### DIFF
--- a/spark-cobol/src/main/scala/za/co/absa/cobrix/spark/cobol/schema/CobolSchema.scala
+++ b/spark-cobol/src/main/scala/za/co/absa/cobrix/spark/cobol/schema/CobolSchema.scala
@@ -135,7 +135,7 @@ class CobolSchema(copybook: Copybook,
           StructField(Constants.fieldNameColumn, StringType, nullable = false),
           StructField(Constants.rawValueColumn, BinaryType, nullable = false)
         )
-      ), containsNull = false), nullable = false)
+      ), containsNull = false), nullable = true)
     } else {
       recordsWithRecordId
     }

--- a/spark-cobol/src/test/scala/za/co/absa/cobrix/spark/cobol/CobolSchemaSpec.scala
+++ b/spark-cobol/src/test/scala/za/co/absa/cobrix/spark/cobol/CobolSchemaSpec.scala
@@ -306,7 +306,7 @@ class CobolSchemaSpec extends AnyWordSpec with SimpleComparisonBase {
           | |    |-- IntValue: integer (nullable = true)
           | |-- STRUCT2: struct (nullable = true)
           | |    |-- STR_FLD: string (nullable = true)
-          | |-- _corrupt_fields: array (nullable = false)
+          | |-- _corrupt_fields: array (nullable = true)
           | |    |-- element: struct (containsNull = false)
           | |    |    |-- field_name: string (nullable = false)
           | |    |    |-- raw_value: binary (nullable = false)

--- a/spark-cobol/src/test/scala/za/co/absa/cobrix/spark/cobol/source/integration/Test41CorruptFieldsSpec.scala
+++ b/spark-cobol/src/test/scala/za/co/absa/cobrix/spark/cobol/source/integration/Test41CorruptFieldsSpec.scala
@@ -51,7 +51,7 @@ class Test41CorruptFieldsSpec extends AnyWordSpec with SparkTestBase with Binary
           | |-- F3: integer (nullable = true)
           | |-- F4: array (nullable = true)
           | |    |-- element: integer (containsNull = true)
-          | |-- _corrupt_fields: array (nullable = false)
+          | |-- _corrupt_fields: array (nullable = true)
           | |    |-- element: struct (containsNull = false)
           | |    |    |-- field_name: string (nullable = false)
           | |    |    |-- raw_value: binary (nullable = false)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Schema Updates**
  * The corrupt-fields array in the generated Spark schema is now nullable instead of non-nullable; nested fields inside that array remain unchanged. This may affect schema validation and handling of corrupt records.

* **Tests**
  * Updated test expectations to reflect the new nullable corrupt-fields schema configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->