### PR TITLE
#841 Add support for file offsets in in-place processors

### DIFF
--- a/README.md
+++ b/README.md
@@ -2011,6 +2011,9 @@ at org.apache.hadoop.io.nativeio.NativeIO$POSIX.getStat(NativeIO.java:608)
 A: Update hadoop dll to version 3.2.2 or newer.
 
 ## Changelog
+- #### 2.10.4 will be released soon.
+   - [#841](https://github.com/AbsaOSS/cobrix/pull/841) Added support for file start and end offset options for in-place processing of files without converting to dataframes.
+
 - #### 2.10.3 released 27 April 2026.
    - [#839](https://github.com/AbsaOSS/cobrix/pull/839) Added `variable_size_occurs = "pad_record"` for fixed-size records where `OCCURS DEPENDING ON` arrays use variable physical storage and the remaining record is padded.
 

--- a/cobol-parser/src/main/scala/za/co/absa/cobrix/cobol/processor/CobolProcessor.scala
+++ b/cobol-parser/src/main/scala/za/co/absa/cobrix/cobol/processor/CobolProcessor.scala
@@ -134,17 +134,17 @@ object CobolProcessor {
       this
     }
 
-    private[processor] def getCobolSchema(readerParameters: ReaderParameters): CobolSchema = {
+    def getCobolSchema(readerParameters: ReaderParameters): CobolSchema = {
       CobolSchema.fromReaderParameters(Seq(copybookContentsOpt.get), readerParameters)
     }
 
-    private[processor] def getReaderParameters: ReaderParameters = {
+    def getReaderParameters: ReaderParameters = {
       val cobolParameters = CobolParametersParser.parse(new Parameters(caseInsensitiveOptions.toMap))
 
       CobolParametersParser.getReaderProperties(cobolParameters, None)
     }
 
-    private[processor] def getOptions: Map[String, String] = caseInsensitiveOptions.toMap
+    private[cobrix] def getOptions: Map[String, String] = caseInsensitiveOptions.toMap
   }
 
   class CobolProcessorLoader(fileToProcess: String,
@@ -160,7 +160,10 @@ object CobolProcessor {
         case CobolProcessingStrategy.ToVariableLength => new CobolProcessorToRdw(readerParameters, copybook, copybookContents, options)
       }
 
-      val recordCount = UsingUtils.using(new FSStream(fileToProcess)) { ifs =>
+      val fileStartOffset = readerParameters.fileStartOffset
+      val fileEndOffset = readerParameters.fileEndOffset
+
+      val recordCount = UsingUtils.using(new FSStream(fileToProcess, fileStartOffset, fileEndOffset)) { ifs =>
         UsingUtils.using(new BufferedOutputStream(new FileOutputStream(outputFile))) { ofs =>
           processor.process(ifs, ofs)(rawRecordProcessor)
         }

--- a/cobol-parser/src/main/scala/za/co/absa/cobrix/cobol/reader/stream/FSStream.scala
+++ b/cobol-parser/src/main/scala/za/co/absa/cobrix/cobol/reader/stream/FSStream.scala
@@ -18,16 +18,22 @@ package za.co.absa.cobrix.cobol.reader.stream
 
 import java.io.{BufferedInputStream, File, FileInputStream, FileNotFoundException, IOException}
 
-class FSStream (fileName: String) extends SimpleStream {
+class FSStream (fileName: String, fileStartOffset: Long = 0L, fileEndOffset: Long = 0L) extends SimpleStream {
   val bytesStream = new BufferedInputStream(new FileInputStream(fileName))
   private var isClosed = false
 
   private val fileSize: Long = new File(fileName).length()
+  private val effectiveSize: Long = fileSize - fileStartOffset - fileEndOffset
   private var byteIndex = 0L
 
-  override def size: Long = fileSize
+  // Skip the start offset if specified
+  if (fileStartOffset > 0) {
+    bytesStream.skip(fileStartOffset)
+  }
 
-  override def totalSize: Long = fileSize
+  override def size: Long = effectiveSize
+
+  override def totalSize: Long = effectiveSize
 
   override def offset: Long = byteIndex
 
@@ -36,8 +42,18 @@ class FSStream (fileName: String) extends SimpleStream {
   @throws(classOf[IOException])
   override def next(numberOfBytes: Int): Array[Byte] = {
     if (numberOfBytes <= 0) throw new IllegalArgumentException("Value of numberOfBytes should be greater than zero.")
-    val b = new Array[Byte](numberOfBytes)
-    val actual = bytesStream.read(b, 0, numberOfBytes)
+
+    // Check if we've reached the effective end of the stream
+    if (byteIndex >= effectiveSize) {
+      close()
+      return new Array[Byte](0)
+    }
+
+    // Calculate how many bytes we can actually read without exceeding effectiveSize
+    val bytesToRead = Math.min(numberOfBytes, (effectiveSize - byteIndex).toInt)
+
+    val b = new Array[Byte](bytesToRead)
+    val actual = bytesStream.read(b, 0, bytesToRead)
     if (actual <= 0) {
       close()
       new Array[Byte](0)
@@ -57,6 +73,6 @@ class FSStream (fileName: String) extends SimpleStream {
 
   @throws(classOf[FileNotFoundException])
   override def copyStream(): SimpleStream = {
-    new FSStream(fileName)
+    new FSStream(fileName, fileStartOffset, fileEndOffset)
   }
 }

--- a/cobol-parser/src/main/scala/za/co/absa/cobrix/cobol/reader/stream/FSStream.scala
+++ b/cobol-parser/src/main/scala/za/co/absa/cobrix/cobol/reader/stream/FSStream.scala
@@ -23,12 +23,12 @@ class FSStream (fileName: String, fileStartOffset: Long = 0L, fileEndOffset: Lon
   private var isClosed = false
 
   private val fileSize: Long = new File(fileName).length()
-  private val effectiveSize: Long = fileSize - fileStartOffset - fileEndOffset
+  private val effectiveSize: Long = math.max(0L, fileSize - fileStartOffset - fileEndOffset)
   private var byteIndex = 0L
 
   // Skip the start offset if specified
   if (fileStartOffset > 0) {
-    bytesStream.skip(fileStartOffset)
+    skipFully(fileStartOffset)
   }
 
   override def size: Long = effectiveSize
@@ -74,5 +74,16 @@ class FSStream (fileName: String, fileStartOffset: Long = 0L, fileEndOffset: Lon
   @throws(classOf[FileNotFoundException])
   override def copyStream(): SimpleStream = {
     new FSStream(fileName, fileStartOffset, fileEndOffset)
+  }
+
+  private def skipFully(bytesToSkip: Long): Unit = {
+    var remaining = math.min(bytesToSkip, fileSize)
+    while (remaining > 0) {
+      val skipped = bytesStream.skip(remaining)
+      if (skipped <= 0) {
+        throw new IOException(s"Unable to skip $bytesToSkip bytes in $fileName.")
+      }
+      remaining -= skipped
+    }
   }
 }

--- a/cobol-parser/src/test/scala/za/co/absa/cobrix/cobol/processor/CobolProcessorBuilderSuite.scala
+++ b/cobol-parser/src/test/scala/za/co/absa/cobrix/cobol/processor/CobolProcessorBuilderSuite.scala
@@ -83,6 +83,35 @@ class CobolProcessorBuilderSuite extends AnyWordSpec with BinaryFileFixture {
         assert(outputArray(3) == -13)
       }
     }
+
+    "support file_start_offset when processing files" in {
+      withTempDirectory("cobol_processor") { tempDir =>
+        val inputFile = Paths.get(tempDir, "input.dat").toString
+        val outputFile = Paths.get(tempDir, "output.dat").toString
+
+        writeBinaryFile(inputFile, Array(0x07, 0x07, 0x07, 0xF1, 0xF2, 0xF3, 0xF4, 0x08, 0x08).map(_.toByte))
+
+        val count = CobolProcessor.builder
+          .withCopybookContents(copybook)
+          .withProcessingStrategy(CobolProcessingStrategy.ToVariableLength)
+          .withRecordProcessor(new RawRecordProcessor {
+            override def processRecord(record: Array[Byte], ctx: CobolProcessorContext): Array[Byte] = {
+              record.map(v => (v - 1).toByte)
+            }
+          })
+          .option("file_start_offset", "3")
+          .option("file_end_offset", "2")
+          .load(inputFile)
+          .save(outputFile)
+
+        val outputData = readBinaryFile(outputFile)
+
+        assert(count == 4)
+        assert(outputData.sameElements(
+          Array(0, 1, 0, 0, -16, 0, 1, 0, 0, -15, 0, 1, 0, 0, -14, 0, 1, 0, 0, -13).map(_.toByte)
+        ))
+      }
+    }
   }
 
   "getCobolSchema" should {

--- a/cobol-parser/src/test/scala/za/co/absa/cobrix/cobol/processor/CobolProcessorBuilderSuite.scala
+++ b/cobol-parser/src/test/scala/za/co/absa/cobrix/cobol/processor/CobolProcessorBuilderSuite.scala
@@ -84,7 +84,7 @@ class CobolProcessorBuilderSuite extends AnyWordSpec with BinaryFileFixture {
       }
     }
 
-    "support file_start_offset when processing files" in {
+    "support file_start_offset when processing files for ToVariableLength strategy" in {
       withTempDirectory("cobol_processor") { tempDir =>
         val inputFile = Paths.get(tempDir, "input.dat").toString
         val outputFile = Paths.get(tempDir, "output.dat").toString
@@ -109,6 +109,35 @@ class CobolProcessorBuilderSuite extends AnyWordSpec with BinaryFileFixture {
         assert(count == 4)
         assert(outputData.sameElements(
           Array(0, 1, 0, 0, -16, 0, 1, 0, 0, -15, 0, 1, 0, 0, -14, 0, 1, 0, 0, -13).map(_.toByte)
+        ))
+      }
+    }
+
+    "support file_start_offset when processing files for InPlace strategy" in {
+      withTempDirectory("cobol_processor") { tempDir =>
+        val inputFile = Paths.get(tempDir, "input.dat").toString
+        val outputFile = Paths.get(tempDir, "output.dat").toString
+
+        writeBinaryFile(inputFile, Array(0x07, 0x07, 0x07, 0xF1, 0xF2, 0xF3, 0xF4, 0x08, 0x08).map(_.toByte))
+
+        val count = CobolProcessor.builder
+          .withCopybookContents(copybook)
+          .withProcessingStrategy(CobolProcessingStrategy.InPlace)
+          .withRecordProcessor(new RawRecordProcessor {
+            override def processRecord(record: Array[Byte], ctx: CobolProcessorContext): Array[Byte] = {
+              record.map(v => (v - 1).toByte)
+            }
+          })
+          .option("file_start_offset", "3")
+          .option("file_end_offset", "2")
+          .load(inputFile)
+          .save(outputFile)
+
+        val outputData = readBinaryFile(outputFile)
+
+        assert(count == 4)
+        assert(outputData.sameElements(
+          Array(-16,-15,-14,-13).map(_.toByte)
         ))
       }
     }

--- a/spark-cobol/src/main/scala/za/co/absa/cobrix/spark/cobol/SparkCobolProcessor.scala
+++ b/spark-cobol/src/main/scala/za/co/absa/cobrix/spark/cobol/SparkCobolProcessor.scala
@@ -26,7 +26,7 @@ import za.co.absa.cobrix.cobol.processor.{CobolProcessingStrategy, CobolProcesso
 import za.co.absa.cobrix.cobol.reader.common.Constants
 import za.co.absa.cobrix.cobol.reader.index.entry.SparseIndexEntry
 import za.co.absa.cobrix.cobol.reader.parameters.CobolParametersParser.PARAM_GENERATE_RECORD_ID
-import za.co.absa.cobrix.cobol.reader.parameters.{CobolParameters, CobolParametersParser, Parameters}
+import za.co.absa.cobrix.cobol.reader.parameters.{CobolParameters, CobolParametersParser, Parameters, ReaderParameters}
 import za.co.absa.cobrix.cobol.reader.schema.CobolSchema
 import za.co.absa.cobrix.cobol.utils.UsingUtils
 import za.co.absa.cobrix.spark.cobol.reader.VarLenReader
@@ -147,17 +147,19 @@ object SparkCobolProcessor {
         throw new IllegalArgumentException("A RawRecordProcessor must be provided.")
       }
 
-      val cobolProcessor = CobolProcessor.builder
+      val cobolProcessorBuilder = CobolProcessor.builder
         .withCopybookContents(copybookContents)
         .withProcessingStrategy(cobolProcessingStrategy)
         .options(options)
-        .build()
+
+      val readerParameters = cobolProcessorBuilder.getReaderParameters
+      val cobolProcessor = cobolProcessorBuilder.build()
 
       val processor = new SparkCobolProcessor {
         private val sconf = new SerializableConfiguration(spark.sparkContext.hadoopConfiguration)
 
         override def process(listOfFiles: Seq[String], outputPath: String): Long = {
-          getFileProcessorRdd(listOfFiles, outputPath, cobolProcessor, rawRecordProcessorOpt.get, sconf, numberOfThreads)
+          getFileProcessorRdd(listOfFiles, outputPath, cobolProcessor, readerParameters, rawRecordProcessorOpt.get, sconf, numberOfThreads)
             .reduce(_ + _)
         }
       }
@@ -185,6 +187,7 @@ object SparkCobolProcessor {
   private def getFileProcessorRdd(listOfFiles: Seq[String],
                                   outputPath: String,
                                   cobolProcessor: CobolProcessor,
+                                  readerParameters: ReaderParameters,
                                   rawRecordProcessor: SerializableRawRecordProcessor,
                                   sconf: SerializableConfiguration,
                                   numberOfThreads: Int
@@ -192,7 +195,7 @@ object SparkCobolProcessor {
     val groupedFiles = listOfFiles.grouped(numberOfThreads).toSeq
     val rdd = spark.sparkContext.parallelize(groupedFiles)
     rdd.map(group => {
-      processListOfFiles(group, outputPath, cobolProcessor, rawRecordProcessor, sconf, numberOfThreads)
+      processListOfFiles(group, outputPath, cobolProcessor, readerParameters, rawRecordProcessor, sconf, numberOfThreads)
     })
   }
 
@@ -248,6 +251,7 @@ object SparkCobolProcessor {
   private def processListOfFiles(listOfFiles: Seq[String],
                                  outputPath: String,
                                  cobolProcessor: CobolProcessor,
+                                 readerParameters: ReaderParameters,
                                  rawRecordProcessor: SerializableRawRecordProcessor,
                                  sconf: SerializableConfiguration,
                                  numberOfThreads: Int
@@ -255,11 +259,14 @@ object SparkCobolProcessor {
     val threadPool: ExecutorService = Executors.newFixedThreadPool(numberOfThreads)
     implicit val ec: ExecutionContext = ExecutionContext.fromExecutorService(threadPool)
 
-    val futures = listOfFiles.map { inputFIle =>
-      val fileName = new Path(inputFIle).getName
+    val futures = listOfFiles.map { inputFile =>
+      val fileName = new Path(inputFile).getName
       val outputPathFileName = new Path(outputPath, fileName).toString
 
-      log.info(s"Processing file: $inputFIle -> $outputPathFileName")
+      log.info(s"Processing file: $inputFile -> $outputPathFileName")
+
+      val fileStartOffset = readerParameters.fileStartOffset
+      val fileEndOffset = readerParameters.fileEndOffset
 
       Future {
         val hadoopConfig = sconf.value
@@ -267,7 +274,12 @@ object SparkCobolProcessor {
         val outputFile = new Path(outputPath, fileName)
         val outputFs = outputFile.getFileSystem(hadoopConfig)
 
-        val recordCount = UsingUtils.using(new FileStreamer(inputFIle, sconf.value)) { ifs =>
+        val maximumBytes = if (fileEndOffset > 0) {
+          FileUtils.getHadoopFileReadSize(inputFile, sconf.value, fileStartOffset, fileEndOffset)
+        } else
+          0L
+
+        val recordCount = UsingUtils.using(new FileStreamer(inputFile, sconf.value, fileStartOffset, maximumBytes)) { ifs =>
           UsingUtils.using(new BufferedOutputStream(outputFs.create(outputFile, true))) { ofs =>
             cobolProcessor.process(ifs, ofs)(rawRecordProcessor)
           }

--- a/spark-cobol/src/main/scala/za/co/absa/cobrix/spark/cobol/source/index/IndexBuilder.scala
+++ b/spark-cobol/src/main/scala/za/co/absa/cobrix/spark/cobol/source/index/IndexBuilder.scala
@@ -230,20 +230,10 @@ private[cobol] object IndexBuilder extends Logging {
     val fileSystem = path.getFileSystem(config)
 
     val startOffset = fileStartOffset
-    val maximumBytes = if (fileEndOffset == 0) {
-      0
+    val maximumBytes = if (fileEndOffset > 0) {
+      FileUtils.getHadoopFileReadSize(filePath, config, fileStartOffset, fileEndOffset, Some(fileSystem))
     } else {
-      val fileSize = if (FileUtils.isCompressed(path, config)) {
-        FileUtils.getCompressedFileSize(path,config)
-      } else {
-        fileSystem.getFileStatus(path).getLen
-      }
-
-      val bytesToRead = fileSize - fileEndOffset - startOffset
-      if (bytesToRead < 0)
-        0
-      else
-        bytesToRead
+      0L
     }
 
     val inputStream = new FileStreamer(filePath, config, startOffset, maximumBytes)

--- a/spark-cobol/src/main/scala/za/co/absa/cobrix/spark/cobol/utils/FileUtils.scala
+++ b/spark-cobol/src/main/scala/za/co/absa/cobrix/spark/cobol/utils/FileUtils.scala
@@ -253,6 +253,22 @@ object FileUtils extends Logging {
     size
   }
 
+  def getHadoopFileReadSize(fileName: String, config: Configuration, fileStartOffset: Long = 0, fileEndOffset: Long = 0, fileSystemOpt: Option[FileSystem] = None): Long = {
+    val path = new Path(fileName)
+    val fileSystem = fileSystemOpt.getOrElse(path.getFileSystem(config))
+    val fileSize = if (FileUtils.isCompressed(path, config)) {
+      FileUtils.getCompressedFileSize(path,config)
+    } else {
+      fileSystem.getFileStatus(path).getLen
+    }
+
+    val bytesToRead = fileSize - fileEndOffset - fileStartOffset
+    if (bytesToRead < 0)
+      0
+    else
+      bytesToRead
+  }
+
   private def isNonDivisible(fileStatus: FileStatus, divisor: Long) = fileStatus.getLen % divisor != 0
 
   /**

--- a/spark-cobol/src/test/scala/za/co/absa/cobrix/spark/cobol/SparkCobolProcessorSuite.scala
+++ b/spark-cobol/src/test/scala/za/co/absa/cobrix/spark/cobol/SparkCobolProcessorSuite.scala
@@ -106,7 +106,7 @@ class SparkCobolProcessorSuite extends AnyWordSpec with SparkTestBase with Binar
       }
     }
 
-    "convert input format into VRL+DRW" in {
+    "convert input format into VRL+RDW" in {
       val expected = """{"T":"0"}{"T":"1"}{"T":"2"}{"T":"3"}"""
       withTempDirectory("spark_cobol_processor") { tempDir =>
         val binData = Array(0xF1, 0xF2, 0xF3, 0xF4).map(_.toByte)
@@ -125,6 +125,51 @@ class SparkCobolProcessorSuite extends AnyWordSpec with SparkTestBase with Binar
               record.map(v => (v - 1).toByte)
             }
           })
+          .load(inputPath)
+          .save(outputPath)
+
+        val outputData = readBinaryFile(outputFile)
+
+        assert(outputData.sameElements(
+          Array(0, 1, 0, 0, -16, 0, 1, 0, 0, -15, 0, 1, 0, 0, -14, 0, 1, 0, 0, -13).map(_.toByte)
+        ))
+
+        val actual = spark.read
+          .format("cobol")
+          .option("copybook_contents", copybook)
+          .option("record_format", "V")
+          .option("is_rdw_big_endian", "true")
+          .option("pedantic", "true")
+          .load(outputFile)
+          .toJSON
+          .collect()
+          .mkString
+
+        assert(actual == expected)
+      }
+    }
+
+    "support file_start_offset and file_end_offset" in {
+      val expected = """{"T":"0"}{"T":"1"}{"T":"2"}{"T":"3"}"""
+      withTempDirectory("spark_cobol_processor") { tempDir =>
+        val binData = Array(0x07, 0x07, 0x07, 0xF1, 0xF2, 0xF3, 0xF4, 0x08, 0x08).map(_.toByte)
+
+        val inputPath = new Path(tempDir, "input.dat").toString
+        val outputPath = new Path(tempDir, "output").toString
+        val outputFile = new Path(outputPath, "input.dat").toString
+
+        writeBinaryFile(inputPath, binData)
+
+        SparkCobolProcessor.builder
+          .withCopybookContents(copybook)
+          .withProcessingStrategy(CobolProcessingStrategy.ToVariableLength)
+          .withRecordProcessor(new SerializableRawRecordProcessor {
+            override def processRecord(record: Array[Byte], ctx: CobolProcessorContext): Array[Byte] = {
+              record.map(v => (v - 1).toByte)
+            }
+          })
+          .option("file_start_offset", "3")
+          .option("file_end_offset", "2")
           .load(inputPath)
           .save(outputPath)
 

--- a/spark-cobol/src/test/scala/za/co/absa/cobrix/spark/cobol/SparkCobolProcessorSuite.scala
+++ b/spark-cobol/src/test/scala/za/co/absa/cobrix/spark/cobol/SparkCobolProcessorSuite.scala
@@ -149,7 +149,51 @@ class SparkCobolProcessorSuite extends AnyWordSpec with SparkTestBase with Binar
       }
     }
 
-    "support file_start_offset and file_end_offset" in {
+    "support file_start_offset and file_end_offset with InPlace strategy" in {
+      val expected = """{"T":"0"}{"T":"1"}{"T":"2"}{"T":"3"}"""
+      withTempDirectory("spark_cobol_processor") { tempDir =>
+        val binData = Array(0x07, 0x07, 0x07, 0xF1, 0xF2, 0xF3, 0xF4, 0x08, 0x08).map(_.toByte)
+
+        val inputPath = new Path(tempDir, "input.dat").toString
+        val outputPath = new Path(tempDir, "output").toString
+        val outputFile = new Path(outputPath, "input.dat").toString
+
+        writeBinaryFile(inputPath, binData)
+
+        SparkCobolProcessor.builder
+          .withCopybookContents(copybook)
+          .withProcessingStrategy(CobolProcessingStrategy.InPlace)
+          .withRecordProcessor(new SerializableRawRecordProcessor {
+            override def processRecord(record: Array[Byte], ctx: CobolProcessorContext): Array[Byte] = {
+              record.map(v => (v - 1).toByte)
+            }
+          })
+          .option("file_start_offset", "3")
+          .option("file_end_offset", "2")
+          .load(inputPath)
+          .save(outputPath)
+
+        val outputData = readBinaryFile(outputFile)
+
+        assert(outputData.sameElements(
+          Array(-16, -15, -14, -13).map(_.toByte)
+        ))
+
+        val actual = spark.read
+          .format("cobol")
+          .option("copybook_contents", copybook)
+          .option("record_format", "F")
+          .option("pedantic", "true")
+          .load(outputFile)
+          .toJSON
+          .collect()
+          .mkString
+
+        assert(actual == expected)
+      }
+    }
+
+    "support file_start_offset and file_end_offset with ToVariableLength strategy" in {
       val expected = """{"T":"0"}{"T":"1"}{"T":"2"}{"T":"3"}"""
       withTempDirectory("spark_cobol_processor") { tempDir =>
         val binData = Array(0x07, 0x07, 0x07, 0xF1, 0xF2, 0xF3, 0xF4, 0x08, 0x08).map(_.toByte)


### PR DESCRIPTION
Closes #841

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for file start/end offset options so processing can skip bytes at file start or end and respect per-file bounds across processing modes.

* **Documentation**
  * Changelog updated for upcoming 2.10.4 release.

* **Tests**
  * Added tests validating offsets for both in-place and variable-length processing and verifying generated binary/JSON outputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->