### PR TITLE
#842 Add options for handling of `null` values when writing EBCDIC files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1694,9 +1694,12 @@ The output looks like this:
 
 ##### Writer-only options
 
-| Option (usage example)           | Description                                                                                                                                                                                                                           |
-|----------------------------------|:--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| .option("strict_schema", "true") | If 'true' (default) Cobrix will throw an exception if a field exists in the copybook but not in the Spark schema. Array count fields (defined in DEPENDING ON clause) are auto-generated and never required to exist in Spark schema. |
+| Option (usage example)                                  | Description                                                                                                                                                                                                                           |
+|---------------------------------------------------------|:--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| .option("strict_schema", "true")                        | If 'true' (default) Cobrix will throw an exception if a field exists in the copybook but not in the Spark schema. Array count fields (defined in DEPENDING ON clause) are auto-generated and never required to exist in Spark schema. |
+| .option("write_null_strings_as_spaces", "false")        | If 'true' Cobrix will write `null` alphanumeric fields as spaces when writing output files.                                                                                                                                           |
+| .option("write_null_display_numbers_as_zeros", "false") | If 'true' Cobrix will write `null` numeric fields having DISPLAY format as serquence of zeros when writing output files.                                                                                                              |
+| .option("write_null_comp3_numbers_as_zeros", "false")   | If 'true' Cobrix will write `null` numeric fields having COMP-3 format as zeros when writing EBCDIC files.                                                                                                                            |
 
 ##### Currently supported EBCDIC code pages
 
@@ -1861,6 +1864,7 @@ df.write
 
 ### Current Limitations
 The writer is still in its early stages and has several limitations:
+- Only EBCDIC output files are supported. Outputting to ASCII is not supported at the moment.
 - Nested GROUPs, OCCURS, OCCURS DEPENDING ON are supported.
 - Variable-size occurs are supported (`variable_size_occurs = true`). Recommended `record_format = "V"`.
 - Writing multi-segment files is not supported.
@@ -2013,6 +2017,12 @@ A: Update hadoop dll to version 3.2.2 or newer.
 ## Changelog
 - #### 2.10.4 will be released soon.
    - [#841](https://github.com/AbsaOSS/cobrix/pull/841) Added support for file start and end offset options for in-place processing of files without converting to dataframes.
+   - [#842](https://github.com/AbsaOSS/cobrix/pull/842) Added support for controlling handling of nulls for various data types when writing EBCDIC files.
+     ```scala
+     .option("write_null_strings_as_spaces", "true")
+     .option("write_null_display_numbers_as_zeros", "true")
+     .option("write_null_comp3_numbers_as_zeros", "true")
+     ```
 
 - #### 2.10.3 released 27 April 2026.
    - [#839](https://github.com/AbsaOSS/cobrix/pull/839) Added `variable_size_occurs = "pad_record"` for fixed-size records where `OCCURS DEPENDING ON` arrays use variable physical storage and the remaining record is padded.

--- a/README.md
+++ b/README.md
@@ -1880,7 +1880,7 @@ The writer is still in its early stages and has several limitations:
 Handling of `PIC X(n)`:
 - Values are truncated when longer than n and right-padded when shorter.
 - The padding byte is EBCDIC space `0x40`.
-- `null` values in DataFrames are written as `0x00` bytes.
+- `null` values in DataFrames are written as `0x00` bytes by default. You can change the behavior using `write_null_strings_as_spaces` option.
 
 Handling of `FILLER`s
 - FILLER areas are populated with 0x00 bytes.

--- a/cobol-parser/src/main/scala/za/co/absa/cobrix/cobol/parser/Copybook.scala
+++ b/cobol-parser/src/main/scala/za/co/absa/cobrix/cobol/parser/Copybook.scala
@@ -18,8 +18,10 @@ package za.co.absa.cobrix.cobol.parser
 
 import za.co.absa.cobrix.cobol.internal.Logging
 import za.co.absa.cobrix.cobol.parser.CopybookParser.CopybookAST
+import za.co.absa.cobrix.cobol.parser.ast.datatype.{AlphaNumeric, COMP3, Decimal, Integral}
 import za.co.absa.cobrix.cobol.parser.ast.{Group, Primitive, Statement}
 import za.co.absa.cobrix.cobol.parser.asttransform.BinaryPropertiesAdder
+import za.co.absa.cobrix.cobol.reader.parameters.WriterParameters
 
 import java.util.concurrent.ConcurrentHashMap
 import scala.collection.mutable
@@ -475,5 +477,80 @@ object Copybook {
       case None =>
         throw new IllegalStateException(s"Cannot set value for field '${field.name}' because it does not have an encoder defined.")
     }
+  }
+
+  /**
+    * Sets the value of a primitive field in the copybook record, with null-aware handling.
+    *
+    * When the value is non-null, delegates to setPrimitiveField to encode the value directly.
+    * When the value is null and the output encoding is EBCDIC, applies special null handling
+    * based on the field's data type and the writer parameters configuration:
+    * - AlphaNumeric fields are filled with EBCDIC space bytes (0x40) if nullStringsAsSpaces is enabled.
+    * - Display numeric (Integral or Decimal without compact encoding) fields are filled with EBCDIC zero bytes (0xF0) if nullDisplayNumbersAsZeros is enabled.
+    * - COMP-3 encoded numeric fields are set to zero if nullComp3NumbersAsZeros is enabled.
+    *
+    * For non-EBCDIC output or when no matching null-handling option is configured, null values
+    * result in no modification to the record bytes.
+    *
+    * @param field                    The AST object of the primitive field to set.
+    * @param writerParameters         The writer configuration parameters controlling null handling behavior.
+    * @param recordBytes              The mutable byte array representing the binary encoded record data.
+    * @param value                    The value to set for the field, or null to trigger null-aware handling.
+    * @param configuredStartOffset    An offset to the beginning of the field in the data (in bytes).
+    * @param fieldStartOffsetOverride If this offset is 0 or negative, the field offset defined by the copybook is used.
+    *                                 Otherwise, the specified offset is used.
+    * @return Unit
+    */
+  def setPrimitiveFieldNullAware(field: Primitive,
+                                writerParameters: WriterParameters,
+                                recordBytes: Array[Byte],
+                                value: Any,
+                                configuredStartOffset: Int = 0,
+                                fieldStartOffsetOverride: Int = 0): Unit = {
+    if (value != null) {
+      setPrimitiveField(field, recordBytes, value, configuredStartOffset, fieldStartOffsetOverride)
+    } else {
+      // Special handling of nulls is supported only in EBCDIC output for now.
+      if (writerParameters.isEbcdic) {
+        val (offset, fieldLength) = getFieldPositionAndSize(field, configuredStartOffset, fieldStartOffsetOverride)
+
+        field.dataType match {
+          case _: AlphaNumeric if writerParameters.nullStringsAsSpaces =>
+            // For string fields, nulls are treated as spaces if the option is set. Since the recordBytes array is initialized with zeroes,
+            // we need to explicitly set space bytes for the field's length.
+            java.util.Arrays.fill(recordBytes, offset, offset + fieldLength, 0x40.toByte)
+          case i: Integral if writerParameters.nullDisplayNumbersAsZeros && i.compact.isEmpty =>
+            java.util.Arrays.fill(recordBytes, offset, offset + fieldLength, 0xF0.toByte)
+          case d: Decimal if writerParameters.nullDisplayNumbersAsZeros && d.compact.isEmpty =>
+            java.util.Arrays.fill(recordBytes, offset, offset + fieldLength, 0xF0.toByte)
+          case i: Integral if writerParameters.nullComp3NumbersAsZeros && i.compact.exists(_.isInstanceOf[COMP3]) =>
+            Copybook.setPrimitiveField(field, recordBytes, 0, configuredStartOffset, fieldStartOffsetOverride)
+          case d: Decimal if writerParameters.nullComp3NumbersAsZeros && d.compact.exists(_.isInstanceOf[COMP3]) =>
+            Copybook.setPrimitiveField(field, recordBytes, new java.math.BigDecimal(0), configuredStartOffset, fieldStartOffsetOverride)
+          case _ => // Nothing to do
+        }
+      }
+    }
+  }
+
+  /**
+    * Calculates the position (offset) and size of a field within binary record data.
+    *
+    * The field's offset is determined by either the fieldStartOffsetOverride (if non-zero)
+    * or by adding the configuredStartOffset to the field's binary properties offset.
+    * The field's size is taken directly from the field's binary properties data size.
+    *
+    * @param field                    The AST object of the field for which to determine position and size.
+    * @param configuredStartOffset    An offset to the beginning of the field in the data (in bytes).
+    * @param fieldStartOffsetOverride If this offset is non-zero, it is used as the field offset directly.
+    *                                 Otherwise, the field offset is computed from configuredStartOffset
+    *                                 plus the field's defined binary properties offset.
+    * @return A tuple where the first element is the field's offset (position) in bytes and
+    *         the second element is the field's size in bytes.
+    */
+  def getFieldPositionAndSize(field: Statement, configuredStartOffset: Int = 0, fieldStartOffsetOverride: Int = 0): (Int, Int) = {
+    val fieldLength = field.binaryProperties.dataSize
+    val offset = if (fieldStartOffsetOverride != 0) fieldStartOffsetOverride else configuredStartOffset + field.binaryProperties.offset
+    (offset, fieldLength)
   }
 }

--- a/cobol-parser/src/main/scala/za/co/absa/cobrix/cobol/parser/Copybook.scala
+++ b/cobol-parser/src/main/scala/za/co/absa/cobrix/cobol/parser/Copybook.scala
@@ -550,7 +550,7 @@ object Copybook {
     */
   def getFieldPositionAndSize(field: Statement, configuredStartOffset: Int = 0, fieldStartOffsetOverride: Int = 0): (Int, Int) = {
     val fieldLength = field.binaryProperties.dataSize
-    val offset = if (fieldStartOffsetOverride != 0) fieldStartOffsetOverride else configuredStartOffset + field.binaryProperties.offset
+    val offset = if (fieldStartOffsetOverride > 0) fieldStartOffsetOverride else configuredStartOffset + field.binaryProperties.offset
     (offset, fieldLength)
   }
 }

--- a/cobol-parser/src/main/scala/za/co/absa/cobrix/cobol/reader/parameters/CobolParameters.scala
+++ b/cobol-parser/src/main/scala/za/co/absa/cobrix/cobol/reader/parameters/CobolParameters.scala
@@ -65,6 +65,7 @@ import za.co.absa.cobrix.cobol.reader.policies.SchemaRetentionPolicy.SchemaReten
   * @param debugIgnoreFileSize     If true the fixed length file reader won't check file size divisibility. Useful for debugging binary file / copybook mismatches.
   * @param debugLayoutPositions    If true, layout positions for input files will be logged (false by default)
   * @param metadataPolicy          Specifies the policy of metadat fields to be added to the Spark schema
+  * @param writerParameters        Parameters set only for the writer of files in mainfraame format
   * @param options                 Options passed to 'spark-cobol'.
   */
 case class CobolParameters(
@@ -113,5 +114,6 @@ case class CobolParameters(
                             metadataPolicy:          MetadataPolicy,
                             fileHeaderField:         Option[String] = None,
                             fileTrailerField:        Option[String] = None,
+                            writerParameters:        Option[WriterParameters],
                             options:                 Map[String, String]
                           )

--- a/cobol-parser/src/main/scala/za/co/absa/cobrix/cobol/reader/parameters/CobolParametersParser.scala
+++ b/cobol-parser/src/main/scala/za/co/absa/cobrix/cobol/reader/parameters/CobolParametersParser.scala
@@ -278,7 +278,7 @@ object CobolParametersParser extends Logging {
     val variableSizeOccursPolicy = VariableSizeOccursPolicy(params.getOrElse(PARAM_VARIABLE_SIZE_OCCURS, "false"))
 
     val writerParameters = if (isWriter) {
-      Some(parseWriterParameters(params: Parameters))
+      Some(parseWriterParameters(params: Parameters, isEbcdic))
     } else {
       None
     }
@@ -336,8 +336,9 @@ object CobolParametersParser extends Logging {
     cobolParameters
   }
 
-  private def parseWriterParameters(parameters: Parameters): WriterParameters = {
+  private def parseWriterParameters(parameters: Parameters, isEbcdic: Boolean): WriterParameters = {
     WriterParameters(
+      isEbcdic = isEbcdic,
       nullStringsAsSpaces = parameters.getOrElse(PARAM_WRITE_NULL_STRINGS_AS_SPACES, "false").toBoolean,
       nullDisplayNumbersAsZeros = parameters.getOrElse(PARAM_WRITE_NULL_DISPLAY_NUMBERS_AS_ZEROS, "false").toBoolean,
       nullComp3NumbersAsZeros = parameters.getOrElse(PARAM_WRITE_NULL_COMP3_NUMBERS_AS_ZEROS, "false").toBoolean

--- a/cobol-parser/src/main/scala/za/co/absa/cobrix/cobol/reader/parameters/CobolParametersParser.scala
+++ b/cobol-parser/src/main/scala/za/co/absa/cobrix/cobol/reader/parameters/CobolParametersParser.scala
@@ -338,7 +338,7 @@ object CobolParametersParser extends Logging {
 
   private def parseWriterParameters(parameters: Parameters): WriterParameters = {
     WriterParameters(
-      nullStringsAsSpaces = parameters.getOrElse(PARAM_WRITE_NULL_STRINGS_AS_SPACES, "true").toBoolean,
+      nullStringsAsSpaces = parameters.getOrElse(PARAM_WRITE_NULL_STRINGS_AS_SPACES, "false").toBoolean,
       nullDisplayNumbersAsZeros = parameters.getOrElse(PARAM_WRITE_NULL_DISPLAY_NUMBERS_AS_ZEROS, "false").toBoolean,
       nullComp3NumbersAsZeros = parameters.getOrElse(PARAM_WRITE_NULL_COMP3_NUMBERS_AS_ZEROS, "false").toBoolean
     )

--- a/cobol-parser/src/main/scala/za/co/absa/cobrix/cobol/reader/parameters/CobolParametersParser.scala
+++ b/cobol-parser/src/main/scala/za/co/absa/cobrix/cobol/reader/parameters/CobolParametersParser.scala
@@ -138,6 +138,11 @@ object CobolParametersParser extends Logging {
   val PARAM_DEBUG_IGNORE_FILE_SIZE    = "debug_ignore_file_size"
   val PARAM_ENABLE_SELF_CHECKS        = "enable_self_checks"
 
+  // Parameters for the writer
+  val PARAM_WRITE_NULL_STRINGS_AS_SPACES           = "write_null_strings_as_spaces"
+  val PARAM_WRITE_NULL_DISPLAY_NUMBERS_AS_ZEROS    = "write_null_display_numbers_as_zeros"
+  val PARAM_WRITE_NULL_COMP3_NUMBERS_AS_ZEROS      = "write_null_comp3_numbers_as_zeros"
+
   private def getSchemaRetentionPolicy(params: Parameters): SchemaRetentionPolicy = {
     val schemaRetentionPolicyName = params.getOrElse(PARAM_SCHEMA_RETENTION_POLICY, "collapse_root")
     val schemaRetentionPolicy = SchemaRetentionPolicy.withNameOpt(schemaRetentionPolicyName)
@@ -230,7 +235,7 @@ object CobolParametersParser extends Logging {
     policy
   }
 
-  def parse(params: Parameters, validateRedundantOptions: Boolean = true): CobolParameters = {
+  def parse(params: Parameters, validateRedundantOptions: Boolean = true, isWriter: Boolean = false): CobolParameters = {
     val schemaRetentionPolicy = getSchemaRetentionPolicy(params)
     val stringTrimmingPolicy = getStringTrimmingPolicy(params)
     val ebcdicCodePageName = params.getOrElse(PARAM_EBCDIC_CODE_PAGE, "common")
@@ -271,6 +276,12 @@ object CobolParametersParser extends Logging {
     }
 
     val variableSizeOccursPolicy = VariableSizeOccursPolicy(params.getOrElse(PARAM_VARIABLE_SIZE_OCCURS, "false"))
+
+    val writerParameters = if (isWriter) {
+      Some(parseWriterParameters(params: Parameters))
+    } else {
+      None
+    }
 
     val cobolParameters = CobolParameters(
       copybookPathOpt,
@@ -318,10 +329,19 @@ object CobolParametersParser extends Logging {
       MetadataPolicy(params.getOrElse(PARAM_METADATA, "basic")),
       params.get(PARAM_RECORD_HEADER_NAME).orElse(params.get(PARAM_RECORD_HEADER_NAME2)) .map(_.trim).filter(_.nonEmpty),
       params.get(PARAM_RECORD_TRAILER_NAME).orElse(params.get(PARAM_RECORD_TRAILER_NAME2)) .map(_.trim).filter(_.nonEmpty),
+      writerParameters,
       params.getMap
       )
     validateSparkCobolOptions(params, recordFormat, validateRedundantOptions)
     cobolParameters
+  }
+
+  private def parseWriterParameters(parameters: Parameters): WriterParameters = {
+    WriterParameters(
+      nullStringsAsSpaces = parameters.getOrElse(PARAM_WRITE_NULL_STRINGS_AS_SPACES, "true").toBoolean,
+      nullDisplayNumbersAsZeros = parameters.getOrElse(PARAM_WRITE_NULL_DISPLAY_NUMBERS_AS_ZEROS, "false").toBoolean,
+      nullComp3NumbersAsZeros = parameters.getOrElse(PARAM_WRITE_NULL_COMP3_NUMBERS_AS_ZEROS, "false").toBoolean
+    )
   }
 
   def getIsEbcdic(params: Parameters, recordFormat: RecordFormat): Boolean = {
@@ -482,6 +502,7 @@ object CobolParametersParser extends Logging {
       varLenParams.inputFileNameColumn,
       parameters.metadataPolicy,
       recordsToExclude,
+      parameters.writerParameters,
       parameters.options
       )
   }

--- a/cobol-parser/src/main/scala/za/co/absa/cobrix/cobol/reader/parameters/ReaderParameters.scala
+++ b/cobol-parser/src/main/scala/za/co/absa/cobrix/cobol/reader/parameters/ReaderParameters.scala
@@ -78,6 +78,8 @@ import za.co.absa.cobrix.cobol.reader.policies.SchemaRetentionPolicy.SchemaReten
   * @param rhpAdditionalInfo       An optional additional option string passed to a custom record header parser
   * @param inputFileNameColumn     A column name to add to the dataframe. The column will contain input file name for each record similar to 'input_file_name()' function
   * @param metadataPolicy          Specifies the policy of metadat fields to be added to the Spark schema
+  * @param recordsToExclude        A set of fields to exclude from decoding in normal (not header or footer) records.
+  * @param writerParameters        If specified, contains parameters for the writer.
   * @param options                 Options passed to spark-cobol
   */
 case class ReaderParameters(
@@ -139,5 +141,6 @@ case class ReaderParameters(
                              inputFileNameColumn:     String = "",
                              metadataPolicy:          MetadataPolicy = MetadataPolicy.Basic,
                              recordsToExclude:       Set[String] = Set.empty,
+                             writerParameters:        Option[WriterParameters] = None,
                              options:                 Map[String, String] = Map.empty
                            )

--- a/cobol-parser/src/main/scala/za/co/absa/cobrix/cobol/reader/parameters/WriterParameters.scala
+++ b/cobol-parser/src/main/scala/za/co/absa/cobrix/cobol/reader/parameters/WriterParameters.scala
@@ -17,6 +17,7 @@
 package za.co.absa.cobrix.cobol.reader.parameters
 
 case class WriterParameters(
+                             isEbcdic: Boolean = true,
                              nullStringsAsSpaces: Boolean = false,
                              nullDisplayNumbersAsZeros: Boolean = false,
                              nullComp3NumbersAsZeros: Boolean = false

--- a/cobol-parser/src/main/scala/za/co/absa/cobrix/cobol/reader/parameters/WriterParameters.scala
+++ b/cobol-parser/src/main/scala/za/co/absa/cobrix/cobol/reader/parameters/WriterParameters.scala
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2018 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.cobrix.cobol.reader.parameters
+
+case class WriterParameters(
+                             nullStringsAsSpaces: Boolean = true,
+                             nullDisplayNumbersAsZeros: Boolean = false,
+                             nullComp3NumbersAsZeros: Boolean = false
+                           )

--- a/cobol-parser/src/main/scala/za/co/absa/cobrix/cobol/reader/parameters/WriterParameters.scala
+++ b/cobol-parser/src/main/scala/za/co/absa/cobrix/cobol/reader/parameters/WriterParameters.scala
@@ -17,7 +17,7 @@
 package za.co.absa.cobrix.cobol.reader.parameters
 
 case class WriterParameters(
-                             nullStringsAsSpaces: Boolean = true,
+                             nullStringsAsSpaces: Boolean = false,
                              nullDisplayNumbersAsZeros: Boolean = false,
                              nullComp3NumbersAsZeros: Boolean = false
                            )

--- a/cobol-parser/src/test/scala/za/co/absa/cobrix/cobol/reader/parameters/CobolParametersParserSuite.scala
+++ b/cobol-parser/src/test/scala/za/co/absa/cobrix/cobol/reader/parameters/CobolParametersParserSuite.scala
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2018 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.cobrix.cobol.reader.parameters
+
+import org.scalatest.wordspec.AnyWordSpec
+
+class CobolParametersParserSuite extends AnyWordSpec {
+  "parse" should {
+    "parse writer parameters" in {
+      val params =  new Parameters(Map(
+        "write_null_strings_as_spaces" -> "false",
+        "write_null_display_numbers_as_zeros" -> "true",
+        "write_null_comp3_numbers_as_zeros" -> "true",
+        "pedantic" -> "true"
+      ))
+
+      val parsedParams = CobolParametersParser.parse(params, isWriter = true)
+      assert(parsedParams.writerParameters.get == WriterParameters(
+        nullStringsAsSpaces = false,
+        nullDisplayNumbersAsZeros = true,
+        nullComp3NumbersAsZeros = true
+      ))
+    }
+  }
+
+}

--- a/spark-cobol/src/main/scala/za/co/absa/cobrix/spark/cobol/source/DefaultSource.scala
+++ b/spark-cobol/src/main/scala/za/co/absa/cobrix/spark/cobol/source/DefaultSource.scala
@@ -83,7 +83,7 @@ class DefaultSource
     val path = parameters.getOrElse("path",
       throw new IllegalArgumentException("Path is required for this data source."))
 
-    val cobolParameters = CobolParametersParser.parse(new Parameters(parameters))
+    val cobolParameters = CobolParametersParser.parse(new Parameters(parameters), isWriter = true)
     CobolParametersValidator.checkSanity(cobolParameters)
 
     val readerParameters = CobolParametersParser.getReaderProperties(cobolParameters, None)

--- a/spark-cobol/src/main/scala/za/co/absa/cobrix/spark/cobol/writer/NestedRecordCombiner.scala
+++ b/spark-cobol/src/main/scala/za/co/absa/cobrix/spark/cobol/writer/NestedRecordCombiner.scala
@@ -390,7 +390,7 @@ object NestedRecordCombiner {
       // ── Plain primitive ──────────────────────────────────────────────────────
       case PrimitiveField(cobolField, getter) =>
         val value = getter(row)
-        setPrimitiveField(cobolField, writerParameters, ar, value, 0, currentOffset)
+        Copybook.setPrimitiveFieldNullAware(cobolField, writerParameters, ar, value, 0, currentOffset)
         cobolField.binaryProperties.actualSize
 
       // ── Primitive which has an OCCURS DEPENDS ON ─────────────────────────────
@@ -430,7 +430,7 @@ object NestedRecordCombiner {
             val elementOffset = baseOffset + i * elementSize
             // fieldStartOffsetOverride is the absolute position; pass it so
             // setPrimitiveField does not add binaryProperties.offset on top again.
-            setPrimitiveField(cobolField, writerParameters, ar, value, fieldStartOffsetOverride = elementOffset)
+            Copybook.setPrimitiveFieldNullAware(cobolField, writerParameters, ar, value, fieldStartOffsetOverride = elementOffset)
             i += 1
           }
           dependingOn.foreach(spec =>
@@ -484,36 +484,6 @@ object NestedRecordCombiner {
           )
           if (variableLengthOccurs) 0 else cobolField.binaryProperties.actualSize
         }
-    }
-  }
-
-  private def setPrimitiveField(field: Primitive,
-                                writerParameters: WriterParameters,
-                                recordBytes: Array[Byte],
-                                value: Any,
-                                configuredStartOffset: Int = 0,
-                                fieldStartOffsetOverride: Int = 0): Unit = {
-    if (value != null) {
-      Copybook.setPrimitiveField(field, recordBytes, value, configuredStartOffset, fieldStartOffsetOverride)
-    } else {
-      val fieldLength = field.binaryProperties.dataSize
-      val offset = if (fieldStartOffsetOverride != 0) fieldStartOffsetOverride else configuredStartOffset + field.binaryProperties.offset
-
-      field.dataType match {
-        case _: AlphaNumeric if writerParameters.nullStringsAsSpaces =>
-          // For string fields, nulls are treated as spaces if the option is set. Since the recordBytes array is initialized with zeroes,
-          // we need to explicitly set space bytes for the field's length.
-          java.util.Arrays.fill(recordBytes, offset, offset + fieldLength, 0x40.toByte)
-        case i: Integral if writerParameters.nullDisplayNumbersAsZeros && i.compact.isEmpty =>
-          java.util.Arrays.fill(recordBytes, offset, offset + fieldLength, 0xF0.toByte)
-        case d: Decimal if writerParameters.nullDisplayNumbersAsZeros && d.compact.isEmpty =>
-          java.util.Arrays.fill(recordBytes, offset, offset + fieldLength, 0xF0.toByte)
-        case i: Integral if writerParameters.nullComp3NumbersAsZeros && i.compact.exists(_.isInstanceOf[COMP3]) =>
-          Copybook.setPrimitiveField(field, recordBytes, 0, configuredStartOffset, fieldStartOffsetOverride)
-        case d: Decimal if writerParameters.nullComp3NumbersAsZeros && d.compact.exists(_.isInstanceOf[COMP3]) =>
-          Copybook.setPrimitiveField(field, recordBytes, new java.math.BigDecimal(0), configuredStartOffset, fieldStartOffsetOverride)
-        case _ => // Nothing to do
-      }
     }
   }
 }

--- a/spark-cobol/src/main/scala/za/co/absa/cobrix/spark/cobol/writer/NestedRecordCombiner.scala
+++ b/spark-cobol/src/main/scala/za/co/absa/cobrix/spark/cobol/writer/NestedRecordCombiner.scala
@@ -21,11 +21,11 @@ import org.apache.spark.sql.types.{ArrayType, StructType}
 import org.apache.spark.sql.{DataFrame, Row}
 import org.slf4j.LoggerFactory
 import za.co.absa.cobrix.cobol.parser.Copybook
-import za.co.absa.cobrix.cobol.parser.ast.datatype.{Decimal, Integral}
+import za.co.absa.cobrix.cobol.parser.ast.datatype.{AlphaNumeric, COMP3, Decimal, Integral}
 import za.co.absa.cobrix.cobol.parser.ast.{Group, Primitive}
 import za.co.absa.cobrix.cobol.parser.policies.VariableSizeOccursPolicy
 import za.co.absa.cobrix.cobol.parser.recordformats.RecordFormat
-import za.co.absa.cobrix.cobol.reader.parameters.ReaderParameters
+import za.co.absa.cobrix.cobol.reader.parameters.{ReaderParameters, WriterParameters}
 import za.co.absa.cobrix.cobol.reader.schema.CobolSchema
 import za.co.absa.cobrix.spark.cobol.writer.WriterAst._
 
@@ -73,7 +73,17 @@ class NestedRecordCombiner extends RecordCombiner {
         s"RDW length $recordLengthLong exceeds ${Int.MaxValue} and cannot be encoded safely."
       )
     }
-    processRDD(df.rdd, cobolSchema.copybook, df.schema, size, adjustment1 + adjustment2, startOffset, hasRdw, isRdwBigEndian, readerParameters.variableSizeOccurs, readerParameters.strictSchema)
+    processRDD(df.rdd,
+      cobolSchema.copybook,
+      df.schema,
+      size,
+      adjustment1 + adjustment2,
+      startOffset,
+      hasRdw,
+      isRdwBigEndian,
+      readerParameters.variableSizeOccurs,
+      readerParameters.strictSchema,
+      readerParameters.writerParameters.get)
   }
 }
 
@@ -156,14 +166,15 @@ object NestedRecordCombiner {
                                  hasRdw: Boolean,
                                  isRdwBigEndian: Boolean,
                                  variableSizeOccurs: VariableSizeOccursPolicy,
-                                 strictSchema: Boolean): RDD[Array[Byte]] = {
+                                 strictSchema: Boolean,
+                                 writerParameters: WriterParameters): RDD[Array[Byte]] = {
     val writerAst = constructWriterAst(copybook, schema, strictSchema)
 
     rdd.mapPartitions { rows =>
       rows.map { row =>
         val ar = new Array[Byte](recordSize)
 
-        val bytesWritten = writeToBytes(writerAst, row, ar, startOffset, variableSizeOccurs != VariableSizeOccursPolicy.MaxSize)
+        val bytesWritten = writeToBytes(writerAst, row, ar, startOffset, variableSizeOccurs != VariableSizeOccursPolicy.MaxSize, writerParameters)
         val recordSizeWritten = if (variableSizeOccurs == VariableSizeOccursPolicy.ShiftRecord) bytesWritten else recordSize - startOffset
 
         if (hasRdw) {
@@ -366,7 +377,12 @@ object NestedRecordCombiner {
     *                             and not always fixed.
     * @throws IllegalArgumentException if a field value cannot be encoded according to the copybook definition.
     */
-  private def writeToBytes(ast: WriterAst, row: Row, ar: Array[Byte], currentOffset: Int, variableLengthOccurs: Boolean): Int = {
+  private def writeToBytes(ast: WriterAst,
+                           row: Row,
+                           ar: Array[Byte],
+                           currentOffset: Int,
+                           variableLengthOccurs: Boolean,
+                           writerParameters: WriterParameters): Int = {
     ast match {
       // ── Filler  ──────────────────────────────────────────────────────────────
       case Filler(size) => size
@@ -374,9 +390,7 @@ object NestedRecordCombiner {
       // ── Plain primitive ──────────────────────────────────────────────────────
       case PrimitiveField(cobolField, getter) =>
         val value = getter(row)
-        if (value != null) {
-          Copybook.setPrimitiveField(cobolField, ar, value, 0, currentOffset)
-        }
+        setPrimitiveField(cobolField, writerParameters, ar, value, 0, currentOffset)
         cobolField.binaryProperties.actualSize
 
       // ── Primitive which has an OCCURS DEPENDS ON ─────────────────────────────
@@ -393,7 +407,7 @@ object NestedRecordCombiner {
         if (nestedRow != null) {
           var writtenBytes = 0
           children.foreach { child =>
-            val written = writeToBytes(child, nestedRow, ar, currentOffset + writtenBytes, variableLengthOccurs)
+            val written = writeToBytes(child, nestedRow, ar, currentOffset + writtenBytes, variableLengthOccurs, writerParameters)
             writtenBytes += written
           }
           writtenBytes
@@ -413,12 +427,10 @@ object NestedRecordCombiner {
           var i = 0
           while (i < elementsToWrite) {
             val value = arr(i)
-            if (value != null) {
-              val elementOffset = baseOffset + i * elementSize
-              // fieldStartOffsetOverride is the absolute position; pass it so
-              // setPrimitiveField does not add binaryProperties.offset on top again.
-              Copybook.setPrimitiveField(cobolField, ar, value, fieldStartOffsetOverride = elementOffset)
-            }
+            val elementOffset = baseOffset + i * elementSize
+            // fieldStartOffsetOverride is the absolute position; pass it so
+            // setPrimitiveField does not add binaryProperties.offset on top again.
+            setPrimitiveField(cobolField, writerParameters, ar, value, fieldStartOffsetOverride = elementOffset)
             i += 1
           }
           dependingOn.foreach(spec =>
@@ -453,7 +465,7 @@ object NestedRecordCombiner {
               // Build an adjusted element offset so that each child's base offset
               // (which is relative to the group's base) lands at the correct position in ar.
               val elementStartOffset = baseOffset + i * elementSize
-              writeToBytes(groupField, elementRow, ar, elementStartOffset, variableLengthOccurs)
+              writeToBytes(groupField, elementRow, ar, elementStartOffset, variableLengthOccurs, writerParameters)
             }
             i += 1
           }
@@ -472,6 +484,36 @@ object NestedRecordCombiner {
           )
           if (variableLengthOccurs) 0 else cobolField.binaryProperties.actualSize
         }
+    }
+  }
+
+  private def setPrimitiveField(field: Primitive,
+                                writerParameters: WriterParameters,
+                                recordBytes: Array[Byte],
+                                value: Any,
+                                configuredStartOffset: Int = 0,
+                                fieldStartOffsetOverride: Int = 0): Unit = {
+    if (value != null) {
+      Copybook.setPrimitiveField(field, recordBytes, value, configuredStartOffset, fieldStartOffsetOverride)
+    } else {
+      val fieldLength = field.binaryProperties.dataSize
+      val offset = if (fieldStartOffsetOverride != 0) fieldStartOffsetOverride else configuredStartOffset + field.binaryProperties.offset
+
+      field.dataType match {
+        case _: AlphaNumeric if writerParameters.nullStringsAsSpaces =>
+          // For string fields, nulls are treated as spaces if the option is set. Since the recordBytes array is initialized with zeroes,
+          // we need to explicitly set space bytes for the field's length.
+          java.util.Arrays.fill(recordBytes, offset, offset + fieldLength, 0x40.toByte)
+        case i: Integral if writerParameters.nullDisplayNumbersAsZeros && i.compact.isEmpty =>
+          java.util.Arrays.fill(recordBytes, offset, offset + fieldLength, 0xF0.toByte)
+        case d: Decimal if writerParameters.nullDisplayNumbersAsZeros && d.compact.isEmpty =>
+          java.util.Arrays.fill(recordBytes, offset, offset + fieldLength, 0xF0.toByte)
+        case i: Integral if writerParameters.nullComp3NumbersAsZeros && i.compact.exists(_.isInstanceOf[COMP3]) =>
+          Copybook.setPrimitiveField(field, recordBytes, 0, configuredStartOffset, fieldStartOffsetOverride)
+        case d: Decimal if writerParameters.nullComp3NumbersAsZeros && d.compact.exists(_.isInstanceOf[COMP3]) =>
+          Copybook.setPrimitiveField(field, recordBytes, new java.math.BigDecimal(0), configuredStartOffset, fieldStartOffsetOverride)
+        case _ => // Nothing to do
+      }
     }
   }
 }

--- a/spark-cobol/src/test/scala/za/co/absa/cobrix/spark/cobol/source/fixtures/TextComparisonFixture.scala
+++ b/spark-cobol/src/test/scala/za/co/absa/cobrix/spark/cobol/source/fixtures/TextComparisonFixture.scala
@@ -21,10 +21,21 @@ import org.scalatest.{Assertion, Suite}
 trait TextComparisonFixture {
   this: Suite =>
 
+  private val ANSI_RED = "\u001B[31m"
+  private val ANSI_RESET = "\u001B[0m"
+
   protected def compareBinary(actual: Array[Byte], expected: Array[Byte], clue: String = "Binary data does not match"): Assertion = {
     if (!actual.sameElements(expected)) {
       println(s"Expected bytes: ${expected.map("%02X" format _).mkString(" ")}")
-      println(s"Actual bytes:   ${actual.map("%02X" format _).mkString(" ")}")
+      val actualFormatted = actual.zipWithIndex.map { case (byte, idx) =>
+        val formatted = "%02X" format byte
+        if (idx >= expected.length || byte != expected(idx)) {
+          s"$ANSI_RED$formatted$ANSI_RESET"
+        } else {
+          formatted
+        }
+      }.mkString(" ")
+      println(s"Actual bytes:   $actualFormatted")
       //println(s"Actual bytes:   ${bytes.map("0x%02X" format _).mkString(", ")}")
 
       assert(actual.sameElements(expected), clue)

--- a/spark-cobol/src/test/scala/za/co/absa/cobrix/spark/cobol/writer/NestedWriterSuite.scala
+++ b/spark-cobol/src/test/scala/za/co/absa/cobrix/spark/cobol/writer/NestedWriterSuite.scala
@@ -824,14 +824,14 @@ class NestedWriterSuite extends AnyWordSpec with SparkTestBase with BinaryFileFi
           .option("write_null_comp3_numbers_as_zeros", "true")
           .save(path.toString)
 
-        val df2 = spark.read.format("cobol")
-          .option("copybook_contents", copybookWithDependingOnWithComp3)
-          .option("record_format", "V")
-          .option("is_rdw_big_endian", "false")
-          .option("is_rdw_part_of_record_length", "true")
-          .option("variable_size_occurs", "true")
-          .load(path.toString)
-        println(SparkUtils.convertDataFrameToPrettyJSON(df2))
+//        val df2 = spark.read.format("cobol")
+//          .option("copybook_contents", copybookWithDependingOnWithComp3)
+//          .option("record_format", "V")
+//          .option("is_rdw_big_endian", "false")
+//          .option("is_rdw_part_of_record_length", "true")
+//          .option("variable_size_occurs", "true")
+//          .load(path.toString)
+//        println(SparkUtils.convertDataFrameToPrettyJSON(df2))
 
         val fs = path.getFileSystem(spark.sparkContext.hadoopConfiguration)
 

--- a/spark-cobol/src/test/scala/za/co/absa/cobrix/spark/cobol/writer/NestedWriterSuite.scala
+++ b/spark-cobol/src/test/scala/za/co/absa/cobrix/spark/cobol/writer/NestedWriterSuite.scala
@@ -23,6 +23,7 @@ import za.co.absa.cobrix.cobol.parser.ast.{Group, Primitive}
 import za.co.absa.cobrix.cobol.parser.{Copybook, CopybookParser}
 import za.co.absa.cobrix.spark.cobol.source.base.SparkTestBase
 import za.co.absa.cobrix.spark.cobol.source.fixtures.{BinaryFileFixture, TextComparisonFixture}
+import za.co.absa.cobrix.spark.cobol.utils.SparkUtils
 
 class NestedWriterSuite extends AnyWordSpec with SparkTestBase with BinaryFileFixture with TextComparisonFixture {
   private val copybookWithOccurs =
@@ -55,6 +56,28 @@ class NestedWriterSuite extends AnyWordSpec with SparkTestBase with BinaryFileFi
       |            10 NAME           PIC X(14).
       |            10 FILLER         PIC X(1).
       |            10 PHONE-NUMBER   PIC X(12).
+      |""".stripMargin
+
+  private val copybookWithDependingOnWithComp3 =
+    """      01 RECORD.
+      |         05  ID               PIC 9(2).
+      |         05  FILLER           PIC 9(1).
+      |         05  NUM1             PIC S9(2).
+      |         05  NUM2             PIC S9(3) COMP-3.
+      |         05  CNT1             PIC 9(1).
+      |         05  NUMBERS          PIC 9(2)
+      |                 OCCURS 0 TO 5 DEPENDING ON CNT1.
+      |         05  PLACE.
+      |            10  COUNTRY-CODE  PIC X(2).
+      |            10  CITY          PIC X(10).
+      |         05  cnt-2             PIC 9(1).
+      |         05  PEOPLE
+      |                 OCCURS 0 TO 3 DEPENDING ON cnt-2.
+      |            10 NAME           PIC X(14).
+      |            10 FILLER         PIC X(1).
+      |            10 PHONE-NUMBER   PIC X(12).
+      |            10  DEC1          PIC 9V9.
+      |            10  DEC2          PIC S99V9 COMP-3.
       |""".stripMargin
 
   "getFieldDefinition" should {
@@ -623,8 +646,8 @@ class NestedWriterSuite extends AnyWordSpec with SparkTestBase with BinaryFileFi
 
     "write the dataframe with OCCURS DEPENDING ON and variable length occurs and null values" in {
       val exampleJsons = Seq(
-        """{"ID":1,"NUMBERS":[10,20,30],"PLACE":{"COUNTRY_CODE":"US","CITY":"New York"}}""",
-        """{"ID":2,"PLACE":{"COUNTRY_CODE":"ZA","CITY":"Cape Town"},"PEOPLE":[{"NAME":"Test User","PHONE_NUMBER":"555-1235"}]}"""
+        """{"ID":1,"NUMBERS":[10,20,30],"PLACE":{"COUNTRY_CODE":"US"}}""",
+        """{"ID":2,"PLACE":{"COUNTRY_CODE":"ZA","CITY":"Cape Town"},"PEOPLE":[{"NAME":"Test User1","PHONE_NUMBER":"555-1235"},{"NAME":"Test User2"}]}"""
       )
 
       import spark.implicits._
@@ -672,12 +695,188 @@ class NestedWriterSuite extends AnyWordSpec with SparkTestBase with BinaryFileFi
         // Expected EBCDIC data for sample test data
         val expected = Array(
           0x1B, 0x00, 0x00, 0x00, // RDW record 0
-          0xF0, 0xF1, 0x00, 0xF3, 0xF1, 0xF0, 0xF2, 0xF0, 0xF3, 0xF0, 0xE4, 0xE2, 0xD5, 0x85, 0xA6, 0x40, 0xE8, 0x96,
-          0x99, 0x92, 0x40, 0x40, 0xF0,
-          0x30, 0x00, 0x00, 0x00,
-          0xF0, 0xF2, 0x00, 0xF0, 0xE9, 0xC1, 0xC3, 0x81, 0x97, 0x85, 0x40, 0xE3, 0x96, 0xA6, 0x95, 0x40, 0xF1, 0xE3,
-          0x85, 0xA2, 0xA3, 0x40, 0xE4, 0xA2, 0x85, 0x99, 0x40, 0x40, 0x40, 0x40, 0x40, 0x00, 0xF5, 0xF5, 0xF5, 0xCA,
-          0xF1, 0xF2, 0xF3, 0xF5, 0x40, 0x40, 0x40, 0x40
+          0xF0, 0xF1, 0x00, 0xF3, 0xF1, 0xF0, 0xF2, 0xF0, 0xF3, 0xF0, 0xE4, 0xE2, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+          0x00, 0x00, 0x00, 0x00, 0xF0,
+          0x4B, 0x00, 0x00, 0x00, // RDW record 1
+          0xF0, 0xF2, 0x00, 0xF0, 0xE9, 0xC1, 0xC3, 0x81, 0x97, 0x85, 0x40, 0xE3, 0x96, 0xA6, 0x95, 0x40, 0xF2, 0xE3,
+          0x85, 0xA2, 0xA3, 0x40, 0xE4, 0xA2, 0x85, 0x99, 0xF1, 0x40, 0x40, 0x40, 0x40, 0x00, 0xF5, 0xF5, 0xF5, 0xCA,
+          0xF1, 0xF2, 0xF3, 0xF5, 0x40, 0x40, 0x40, 0x40,
+          0xE3, 0x85, 0xA2, 0xA3, 0x40, 0xE4, 0xA2, 0x85, 0x99, 0xF2, 0x40, 0x40, 0x40, 0x40, 0x00, 0x00, 0x00, 0x00,
+          0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+        ).map(_.toByte)
+
+        compareBinary(bytes, expected, "Written data should match expected EBCDIC encoding")
+      }
+    }
+
+    "write the dataframe with OCCURS DEPENDING ON and variable length occurs and null values and COMP-3 numbers" in {
+      val exampleJsons = Seq(
+        """{"ID":1,"NUM1":10,"NUM2":-100,"NUMBERS":[10,20,30],"PLACE":{"COUNTRY_CODE":"US"}}""",
+        """{"ID":2,"PLACE":{"COUNTRY_CODE":"ZA","CITY":"Cape Town"},"PEOPLE":[{"NAME":"Test User1","PHONE_NUMBER":"555-1235","DEC1":1.2,"DEC2":-10.2},{"NAME":"Test User2"}]}"""
+      )
+
+      import spark.implicits._
+
+      val df = spark.read.json(exampleJsons.toDS())
+        .select("ID", "NUM1", "NUM2", "NUMBERS", "PLACE", "PEOPLE")
+
+      withTempDirectory("cobol_writer3") { tempDir =>
+        val path = new Path(tempDir, "writer3")
+
+        df.coalesce(1)
+          .orderBy("id")
+          .write
+          .format("cobol")
+          .mode(SaveMode.Overwrite)
+          .option("copybook_contents", copybookWithDependingOnWithComp3)
+          .option("record_format", "V")
+          .option("is_rdw_big_endian", "false")
+          .option("is_rdw_part_of_record_length", "true")
+          .option("variable_size_occurs", "true")
+          .save(path.toString)
+
+//        val df2 = spark.read.format("cobol")
+//          .option("copybook_contents", copybookWithDependingOnWithComp3)
+//          .option("record_format", "V")
+//          .option("is_rdw_big_endian", "false")
+//          .option("is_rdw_part_of_record_length", "true")
+//          .option("variable_size_occurs", "true")
+//          .load(path.toString)
+//        println(SparkUtils.convertDataFrameToPrettyJSON(df2))
+
+        val fs = path.getFileSystem(spark.sparkContext.hadoopConfiguration)
+
+        assert(fs.exists(path), "Output directory should exist")
+        val files = fs.listStatus(path)
+          .filter(_.getPath.getName.startsWith("part-"))
+        assert(files.nonEmpty, "Output directory should contain part files")
+
+        val partFile = files.head.getPath
+        val data = fs.open(partFile)
+        val bytes = new Array[Byte](files.head.getLen.toInt)
+        data.readFully(bytes)
+        data.close()
+
+        // Expected EBCDIC data for sample test data
+        val expected = Array(
+          0x1F, 0x00, 0x00, 0x00, // RDW record 0
+          0xF0, 0xF1, // ID
+          0x00, // FILLER
+          0xF1, 0xC0, // 10 DISPLAY
+          0x10, 0x0D, // -100 COMP-3
+          0xF3, // CNT1
+          0xF1, 0xF0, 0xF2, 0xF0, 0xF3, 0xF0, // NUMBERS
+          0xE4, 0xE2, // COUNTRY-CODE
+          0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // null as CITY
+          0xF0, // CNT2
+
+          0x57, 0x00, 0x00, 0x00, // RDW record 1
+          0xF0, 0xF2, // ID
+          0x00, // FILLER
+          0x00, 0x00, // null as DISPLAY
+          0x00, 0x00, // null as COMP-3
+          0xF0, // CNT1
+          0xE9, 0xC1, // COUNTRY-CODE
+          0xC3, 0x81, 0x97, 0x85, 0x40, 0xE3, 0x96, 0xA6, 0x95, 0x40, // CITY
+          0xF2, // CNT2
+          0xE3, 0x85, 0xA2, 0xA3, 0x40, 0xE4, 0xA2, 0x85, 0x99, 0xF1, 0x40, 0x40, 0x40, 0x40, // NAME
+          0x00, // FILLER
+          0xF5, 0xF5, 0xF5, 0xCA, 0xF1, 0xF2, 0xF3, 0xF5, 0x40, 0x40, 0x40, 0x40, // PHONE-NUMBER
+          0xF1, 0xF2, // 1.2 DISPLAY
+          0x10, 0x2D, //-10.2 COMP-3
+          0xE3, 0x85, 0xA2, 0xA3, 0x40, 0xE4, 0xA2, 0x85, 0x99, 0xF2, 0x40, 0x40, 0x40, 0x40, // NAME
+          0x00, // FILLER
+          0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // null as PHONE-NUMBER
+          0x00, 0x00, // null decimal DISPLAY
+          0x00, 0x00 // null decimal COMP-3
+        ).map(_.toByte)
+
+        compareBinary(bytes, expected, "Written data should match expected EBCDIC encoding")
+      }
+    }
+
+    "write the dataframe with OCCURS DEPENDING ON and variable length occurs and null values and COMP-3 numbers with non-default null handlers" in {
+      val exampleJsons = Seq(
+        """{"ID":1,"NUM1":10,"NUM2":-100,"NUMBERS":[10,20,30],"PLACE":{"COUNTRY_CODE":"US"}}""",
+        """{"ID":2,"PLACE":{"COUNTRY_CODE":"ZA","CITY":"Cape Town"},"PEOPLE":[{"NAME":"Test User1","PHONE_NUMBER":"555-1235","DEC1":1.2,"DEC2":-10.2},{"NAME":"Test User2"}]}"""
+      )
+
+      import spark.implicits._
+
+      val df = spark.read.json(exampleJsons.toDS())
+        .select("ID", "NUM1", "NUM2", "NUMBERS", "PLACE", "PEOPLE")
+
+      withTempDirectory("cobol_writer3") { tempDir =>
+        val path = new Path(tempDir, "writer3")
+
+        df.coalesce(1)
+          .orderBy("id")
+          .write
+          .format("cobol")
+          .mode(SaveMode.Overwrite)
+          .option("copybook_contents", copybookWithDependingOnWithComp3)
+          .option("record_format", "V")
+          .option("is_rdw_big_endian", "false")
+          .option("is_rdw_part_of_record_length", "true")
+          .option("variable_size_occurs", "true")
+          .option("write_null_strings_as_spaces", "true")
+          .option("write_null_display_numbers_as_zeros", "true")
+          .option("write_null_comp3_numbers_as_zeros", "true")
+          .save(path.toString)
+
+        val df2 = spark.read.format("cobol")
+          .option("copybook_contents", copybookWithDependingOnWithComp3)
+          .option("record_format", "V")
+          .option("is_rdw_big_endian", "false")
+          .option("is_rdw_part_of_record_length", "true")
+          .option("variable_size_occurs", "true")
+          .load(path.toString)
+        println(SparkUtils.convertDataFrameToPrettyJSON(df2))
+
+        val fs = path.getFileSystem(spark.sparkContext.hadoopConfiguration)
+
+        assert(fs.exists(path), "Output directory should exist")
+        val files = fs.listStatus(path)
+          .filter(_.getPath.getName.startsWith("part-"))
+        assert(files.nonEmpty, "Output directory should contain part files")
+
+        val partFile = files.head.getPath
+        val data = fs.open(partFile)
+        val bytes = new Array[Byte](files.head.getLen.toInt)
+        data.readFully(bytes)
+        data.close()
+
+        // Expected EBCDIC data for sample test data
+        val expected = Array(
+          0x1F, 0x00, 0x00, 0x00, // RDW record 0
+          0xF0, 0xF1, // ID
+          0x00, // FILLER
+          0xF1, 0xC0, // 10 DISPLAY
+          0x10, 0x0D, // -100 COMP-3
+          0xF3, // CNT1
+          0xF1, 0xF0, 0xF2, 0xF0, 0xF3, 0xF0, // NUMBERS
+          0xE4, 0xE2, // COUNTRY-CODE
+          0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, // CITY
+          0xF0, // CNT2
+
+          0x57, 0x00, 0x00, 0x00, // RDW record 1
+          0xF0, 0xF2, // ID
+          0x00, // FILLER
+          0xF0, 0xF0, // null as DISPLAY
+          0x00, 0x0C, // null as COMP-3
+          0xF0, // CNT1
+          0xE9, 0xC1, // COUNTRY-CODE
+          0xC3, 0x81, 0x97, 0x85, 0x40, 0xE3, 0x96, 0xA6, 0x95, 0x40, // CITY
+          0xF2, // CNT2
+          0xE3, 0x85, 0xA2, 0xA3, 0x40, 0xE4, 0xA2, 0x85, 0x99, 0xF1, 0x40, 0x40, 0x40, 0x40, // NAME
+          0x00, // FILLER
+          0xF5, 0xF5, 0xF5, 0xCA, 0xF1, 0xF2, 0xF3, 0xF5, 0x40, 0x40, 0x40, 0x40, // PHONE-NUMBER
+          0xF1, 0xF2, // 1.2 DISPLAY
+          0x10, 0x2D, //-10.2 COMP-3
+          0xE3, 0x85, 0xA2, 0xA3, 0x40, 0xE4, 0xA2, 0x85, 0x99, 0xF2, 0x40, 0x40, 0x40, 0x40, // NAME
+          0x00, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, // null as PHONE-NUMBER
+          0xF0, 0xF0, // null decimal DISPLAY
+          0x00, 0x0C // null decimal COMP-3
         ).map(_.toByte)
 
         compareBinary(bytes, expected, "Written data should match expected EBCDIC encoding")


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced three new writer-only configuration options for null value handling during EBCDIC output: `write_null_strings_as_spaces`, `write_null_display_numbers_as_zeros`, and `write_null_comp3_numbers_as_zeros`.
  * Enhanced null-aware support for primitive fields during COBOL copybook writing.

* **Documentation**
  * Simplified limitations section in README, retaining only EBCDIC output restrictions.

* **Tests**
  * Expanded test coverage for null handling scenarios with variable-length fields and COMP-3 number encoding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->