### PR TITLE
#853 Fix IBM single precision floating point (COMP-1) decoder to produce correct results.

### DIFF
--- a/cobol-parser/src/main/scala/za/co/absa/cobrix/cobol/parser/decoders/FloatingPointDecoders.scala
+++ b/cobol-parser/src/main/scala/za/co/absa/cobrix/cobol/parser/decoders/FloatingPointDecoders.scala
@@ -117,54 +117,27 @@ object FloatingPointDecoders {
   /**
     * Decode IBM single precision big endian encoded number.
     *
-    * The source code of this function is based on ibm2ieee NumPy library
-    * Copyright (c) 2018, Enthought, Inc.
-    *
-    * The source code for this method is distributed via 3-clause BSD license.
+    * The method correctly converts bytes in examples here:
+    *   https://www.ibm.com/docs/en/cobol-zos/6.3.0?topic=data-examples-numeric-internal-representation
     *
     * @param bytes An array of bytes
     * @return a converted single precision floating point number
     */
   def decodeIbmSingleBigEndian(bytes: Array[Byte]): java.lang.Float = {
+    val b0 = bytes(0) & 0xFF
+    val b1 = bytes(1) & 0xFF
+    val b2 = bytes(2) & 0xFF
+    val b3 = bytes(3) & 0xFF
+
+    val fracInt = (b1 << 16) | (b2 << 8) | b3
+    if ((b0 | fracInt) == 0) return 0.0f
+
     try {
-      val IBM32_SIGN_MASK = 0x80000000
-      val IBM32_EXPONENT_MASK = 0x80000000
-      val IBM32_FRACTURE_MASK = 0x00FFFFFF
-      val IBM32_MS_NIBBLE = 0x00F00000
+      val fraction = fracInt.toFloat * (1.0f / (1 << 24))
+      val sign = if ((b0 & 0x80) != 0) -1.0f else 1.0f
+      val exp16 = (b0 & 0x7F) - 64
 
-      val mantissa = (bytes(0) << 24) | ((bytes(1) & 255) << 16) | ((bytes(2) & 255) << 8) | (bytes(3) & 255)
-      val sign = mantissa & IBM32_SIGN_MASK
-      var fracture = mantissa & IBM32_FRACTURE_MASK
-      var exponent = (mantissa & IBM32_EXPONENT_MASK) >> 22
-
-      if (fracture == 0L) {
-        0.0f
-      } else {
-        var topNibble = fracture & IBM32_MS_NIBBLE
-        while (topNibble == 0) {
-          fracture <<= 4
-          exponent -= 4
-          topNibble = fracture & IBM32_MS_NIBBLE
-        }
-        val leadingZeros = ((BIT_COUNT_MAGIC >> (topNibble >> 19)) & 3).toInt
-        fracture <<= leadingZeros
-        val convertedExp = exponent + 131 - leadingZeros
-
-        if (convertedExp >=0 && convertedExp < 254) {
-          val ieee754Int = sign + (convertedExp << 23) + fracture
-          java.lang.Float.intBitsToFloat(ieee754Int)
-        } else if (convertedExp > 254) {
-          java.lang.Float.POSITIVE_INFINITY
-        } else if (convertedExp >= -32) {
-          val mask = ~(0xFFFFFFFD << (-1 - convertedExp))
-          val roundUp = if ((fracture & mask) > 0) 1 else 0
-          val convertedFract = ((fracture >> (-1 - convertedExp)) + roundUp) >> 1
-          val ieee754Int = sign + convertedFract
-          java.lang.Float.intBitsToFloat(ieee754Int)
-        } else {
-          0.0f
-        }
-      }
+      sign * Math.scalb(fraction, exp16 * 4)
     } catch {
       case NonFatal(_) => null
     }

--- a/cobol-parser/src/main/scala/za/co/absa/cobrix/cobol/parser/decoders/FloatingPointDecoders.scala
+++ b/cobol-parser/src/main/scala/za/co/absa/cobrix/cobol/parser/decoders/FloatingPointDecoders.scala
@@ -124,20 +124,22 @@ object FloatingPointDecoders {
     * @return a converted single precision floating point number
     */
   def decodeIbmSingleBigEndian(bytes: Array[Byte]): java.lang.Float = {
-    val b0 = bytes(0) & 0xFF
-    val b1 = bytes(1) & 0xFF
-    val b2 = bytes(2) & 0xFF
-    val b3 = bytes(3) & 0xFF
-
-    val fracInt = (b1 << 16) | (b2 << 8) | b3
-    if ((b0 | fracInt) == 0) return 0.0f
-
     try {
-      val fraction = fracInt.toFloat * (1.0f / (1 << 24))
-      val sign = if ((b0 & 0x80) != 0) -1.0f else 1.0f
-      val exp16 = (b0 & 0x7F) - 64
+      val b0 = bytes(0) & 0xFF
+      val b1 = bytes(1) & 0xFF
+      val b2 = bytes(2) & 0xFF
+      val b3 = bytes(3) & 0xFF
+      val fracInt = (b1 << 16) | (b2 << 8) | b3
 
-      sign * Math.scalb(fraction, exp16 * 4)
+      if ((b0 | fracInt) == 0) {
+        0.0f
+      } else {
+        val fraction = fracInt.toFloat * (1.0f / (1 << 24))
+        val sign = if ((b0 & 0x80) != 0) -1.0f else 1.0f
+        val exp16 = (b0 & 0x7F) - 64
+
+        sign * Math.scalb(fraction, exp16 * 4)
+      }
     } catch {
       case NonFatal(_) => null
     }

--- a/cobol-parser/src/main/scala/za/co/absa/cobrix/cobol/parser/decoders/FloatingPointDecoders.scala
+++ b/cobol-parser/src/main/scala/za/co/absa/cobrix/cobol/parser/decoders/FloatingPointDecoders.scala
@@ -117,28 +117,53 @@ object FloatingPointDecoders {
   /**
     * Decode IBM single precision big endian encoded number.
     *
-    * The method correctly converts bytes in examples here:
-    *   https://www.ibm.com/docs/en/cobol-zos/6.3.0?topic=data-examples-numeric-internal-representation
+    * The source code of this function is based on ibm2ieee NumPy library
+    * Copyright (c) 2018, Enthought, Inc.
+    *
+    * The source code for this method is distributed via 3-clause BSD license.
     *
     * @param bytes An array of bytes
     * @return a converted single precision floating point number
     */
   def decodeIbmSingleBigEndian(bytes: Array[Byte]): java.lang.Float = {
     try {
-      val b0 = bytes(0) & 0xFF
-      val b1 = bytes(1) & 0xFF
-      val b2 = bytes(2) & 0xFF
-      val b3 = bytes(3) & 0xFF
-      val fracInt = (b1 << 16) | (b2 << 8) | b3
+      val IBM32_SIGN_MASK = 0x80000000
+      val IBM32_EXPONENT_MASK = 0x7F000000
+      val IBM32_FRACTURE_MASK = 0x00FFFFFF
+      val IBM32_MS_NIBBLE = 0x00F00000
 
-      if ((b0 | fracInt) == 0) {
+      val mantissa = (bytes(0) << 24) | ((bytes(1) & 255) << 16) | ((bytes(2) & 255) << 8) | (bytes(3) & 255)
+      val sign = mantissa & IBM32_SIGN_MASK
+      var fracture = mantissa & IBM32_FRACTURE_MASK
+      var exponent = (mantissa & IBM32_EXPONENT_MASK) >> 22
+
+      if (fracture == 0L) {
         0.0f
       } else {
-        val fraction = fracInt.toFloat * (1.0f / (1 << 24))
-        val sign = if ((b0 & 0x80) != 0) -1.0f else 1.0f
-        val exp16 = (b0 & 0x7F) - 64
+        var topNibble = fracture & IBM32_MS_NIBBLE
+        while (topNibble == 0) {
+          fracture <<= 4
+          exponent -= 4
+          topNibble = fracture & IBM32_MS_NIBBLE
+        }
+        val leadingZeros = ((BIT_COUNT_MAGIC >> (topNibble >> 19)) & 3).toInt
+        fracture <<= leadingZeros
+        val convertedExp = exponent - 131 - leadingZeros
 
-        sign * Math.scalb(fraction, exp16 * 4)
+        if (convertedExp >=0 && convertedExp < 254) {
+          val ieee754Int = sign + (convertedExp << 23) + fracture
+          java.lang.Float.intBitsToFloat(ieee754Int)
+        } else if (convertedExp > 254) {
+          java.lang.Float.POSITIVE_INFINITY
+        } else if (convertedExp >= -32) {
+          val mask = ~(0xFFFFFFFD << (-1 - convertedExp))
+          val roundUp = if ((fracture & mask) > 0) 1 else 0
+          val convertedFract = ((fracture >> (-1 - convertedExp)) + roundUp) >> 1
+          val ieee754Int = sign + convertedFract
+          java.lang.Float.intBitsToFloat(ieee754Int)
+        } else {
+          0.0f
+        }
       }
     } catch {
       case NonFatal(_) => null

--- a/cobol-parser/src/test/scala/za/co/absa/cobrix/cobol/parser/decoders/FloatingPointDecodersSpec.scala
+++ b/cobol-parser/src/test/scala/za/co/absa/cobrix/cobol/parser/decoders/FloatingPointDecodersSpec.scala
@@ -29,10 +29,52 @@ class FloatingPointDecodersSpec extends AnyWordSpec {
   }
 
   "decodeIbmSingleBigEndian()" should {
-    "decode IBM single precision / big-endian FP numbers" in {
+    "decode IBM single precision / big-endian FP number 1.0" in {
       val bytes = Array[Byte](
-        0x43.toByte, 0x14.toByte, 0x2E.toByte, 0xFC.toByte)
-      assertFloatEqual(FloatingPointDecoders.decodeIbmSingleBigEndian(bytes), 5.045883f)
+        0x41.toByte, 0x10.toByte, 0x00.toByte, 0x00.toByte)
+      assertFloatEqual(FloatingPointDecoders.decodeIbmSingleBigEndian(bytes), 1.0f)
+    }
+
+    "decode IBM single precision / big-endian FP number 1234.0" in {
+      val bytes = Array[Byte](
+        0x43.toByte, 0x4D.toByte, 0x20.toByte, 0x00.toByte)
+      assertFloatEqual(FloatingPointDecoders.decodeIbmSingleBigEndian(bytes), 1234.0f)
+    }
+
+    "decode IBM single precision / big-endian FP number -1234.0" in {
+      val bytes = Array[Byte](
+        0xC3.toByte, 0x4D.toByte, 0x20.toByte, 0x00.toByte)
+      assertFloatEqual(FloatingPointDecoders.decodeIbmSingleBigEndian(bytes), -1234.0f)
+    }
+
+    "decode IBM single precision / big-endian FP number 4.5" in {
+      val bytes = Array[Byte](
+        0x41.toByte, 0x48.toByte, 0x00.toByte, 0x00.toByte)
+      assertFloatEqual(FloatingPointDecoders.decodeIbmSingleBigEndian(bytes), 4.5f)
+    }
+
+    "decode IBM single precision / big-endian FP number -3.75" in {
+      val bytes = Array[Byte](
+        0xC1.toByte, 0x3C.toByte, 0x00.toByte, 0x00.toByte)
+      assertFloatEqual(FloatingPointDecoders.decodeIbmSingleBigEndian(bytes), -3.75f)
+    }
+
+    "decode IBM single precision / big-endian FP number 2.5" in {
+      val bytes = Array[Byte](
+        0x41.toByte, 0x28.toByte, 0x00.toByte, 0x00.toByte)
+      assertFloatEqual(FloatingPointDecoders.decodeIbmSingleBigEndian(bytes), 2.5f)
+    }
+
+    "decode IBM single precision / big-endian FP number 0" in {
+      val bytes = Array[Byte](
+        0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte)
+      assertFloatEqual(FloatingPointDecoders.decodeIbmSingleBigEndian(bytes), 0f)
+    }
+
+    "decode IBM single precision / big-endian FP number infinity" in {
+      val bytes = Array[Byte](
+        0x7F.toByte, 0xFF.toByte, 0xFF.toByte, 0xFF.toByte)
+      assert(FloatingPointDecoders.decodeIbmSingleBigEndian(bytes).isInfinite)
     }
   }
 
@@ -53,10 +95,40 @@ class FloatingPointDecodersSpec extends AnyWordSpec {
   }
 
   "decodeIbmSingleLittleEndian()" should {
-    "decode IBM single precision / little-endian FP numbers" in {
+    "decode IBM single precision / little-endian FP number 1.0" in {
       val bytes = Array[Byte](
-        0xFC.toByte, 0x2E.toByte, 0x14.toByte, 0x43.toByte)
-      assertFloatEqual(FloatingPointDecoders.decodeIbmSingleLittleEndian(bytes), 5.045883f)
+        0x00.toByte, 0x00.toByte, 0x10.toByte, 0x41.toByte)
+      assertFloatEqual(FloatingPointDecoders.decodeIbmSingleLittleEndian(bytes), 1.0f)
+    }
+
+    "decode IBM single precision / little-endian FP number 1234.0" in {
+      val bytes = Array[Byte](
+        0x00.toByte, 0x20.toByte, 0x4D.toByte, 0x43.toByte)
+      assertFloatEqual(FloatingPointDecoders.decodeIbmSingleLittleEndian(bytes), 1234.0f)
+    }
+
+    "decode IBM single precision / little-endian FP number -1234.0" in {
+      val bytes = Array[Byte](
+        0x00.toByte, 0x20.toByte, 0x4D.toByte, 0xC3.toByte)
+      assertFloatEqual(FloatingPointDecoders.decodeIbmSingleLittleEndian(bytes), -1234.0f)
+    }
+
+    "decode IBM single precision / little-endian FP number 4.5" in {
+      val bytes = Array[Byte](
+        0x00.toByte, 0x00.toByte, 0x48.toByte, 0x41.toByte)
+      assertFloatEqual(FloatingPointDecoders.decodeIbmSingleLittleEndian(bytes), 4.5f)
+    }
+
+    "decode IBM single precision / little-endian FP number -3.75" in {
+      val bytes = Array[Byte](
+        0x00.toByte, 0x00.toByte, 0x3C.toByte, 0xC1.toByte)
+      assertFloatEqual(FloatingPointDecoders.decodeIbmSingleLittleEndian(bytes), -3.75f)
+    }
+
+    "decode IBM single precision / big-endian FP number infinity" in {
+      val bytes = Array[Byte](
+        0xFF.toByte, 0xFF.toByte, 0xFF.toByte, 0x7F.toByte)
+      assert(FloatingPointDecoders.decodeIbmSingleBigEndian(bytes).isInfinite)
     }
   }
 

--- a/cobol-parser/src/test/scala/za/co/absa/cobrix/cobol/parser/decoders/FloatingPointDecodersSpec.scala
+++ b/cobol-parser/src/test/scala/za/co/absa/cobrix/cobol/parser/decoders/FloatingPointDecodersSpec.scala
@@ -125,10 +125,10 @@ class FloatingPointDecodersSpec extends AnyWordSpec {
       assertFloatEqual(FloatingPointDecoders.decodeIbmSingleLittleEndian(bytes), -3.75f)
     }
 
-    "decode IBM single precision / big-endian FP number infinity" in {
+    "decode IBM single precision / little-endian FP number infinity" in {
       val bytes = Array[Byte](
         0xFF.toByte, 0xFF.toByte, 0xFF.toByte, 0x7F.toByte)
-      assert(FloatingPointDecoders.decodeIbmSingleBigEndian(bytes).isInfinite)
+      assert(FloatingPointDecoders.decodeIbmSingleLittleEndian(bytes).isInfinite)
     }
   }
 

--- a/spark-cobol/src/test/scala/za/co/absa/cobrix/spark/cobol/source/regression/Test03IbmFloats.scala
+++ b/spark-cobol/src/test/scala/za/co/absa/cobrix/spark/cobol/source/regression/Test03IbmFloats.scala
@@ -114,7 +114,7 @@ class Test03IbmFloats extends AnyFunSuite with BeforeAndAfterAll with SparkTestB
     val f = df.select(col("F")).take(1)(0)(0).asInstanceOf[Float]
     val d = df.select(col("D")).take(1)(0)(0).asInstanceOf[Double]
 
-    assertFloatEqual(f, 5.045883f)
+    assertFloatEqual(f, 322.93652f)
     assertDoubleEqual(d, 322.936717)
   }
 
@@ -132,7 +132,7 @@ class Test03IbmFloats extends AnyFunSuite with BeforeAndAfterAll with SparkTestB
     val f = df.select(col("F")).take(1)(0)(0).asInstanceOf[Float]
     val d = df.select(col("D")).take(1)(0)(0).asInstanceOf[Double]
 
-    assertFloatEqual(f, 5.045883f)
+    assertFloatEqual(f, 322.93652f)
     assertDoubleEqual(d, 322.936717)
   }
 


### PR DESCRIPTION
Closes #853

  1. Fixed exponent mask (line 131): Changed from 0x80000000 → 0x7F000000                                                                                                                                                                                                                                                         
    - The original mask was incorrect (same as sign mask)                                                                           
    - Proper mask now extracts the 7-bit IBM exponent correctly                                                                                                                                                                                                                                                                   
  2. Fixed exponent conversion (line 151): Changed from + 131 → - 131                                                                                                                                                                                                                                                             
    - IBM uses base-16 exponent bias of 64 vs IEEE-754's base-2 bias of 127                                                                                                                                                                                                                                                       
    - Correct formula: ieee_exp = (ibm_exp - 64) * 4 + 127 - leading_zeros                                                                                                                                                                                                                                                        
    - Simplified to: ibm_exp * 4 - 131 - leading_zeros                                                                                                                                                                                                                                                                            
                                                                                                                                                                                                                                                                                                                                  
  Test Updates                                                                                                                                                                                                                                                                                                                    
                                                                                                                                                                                                                                                                                                                                  
  - FloatingPointDecodersSpec.scala: Replaced incorrect test (5.045883) with comprehensive test suite covering:                                                                                                                                                                                                                   
    - Basic values (1.0, 1234.0, 4.5, 2.5)                                                                                          
    - Negative numbers (-1234.0, -3.75)                                                                                                                                                                                                                                                                                           
    - Edge cases (0, infinity)                                                                                                      
    - Both big-endian and little-endian variants                                                                                                                                                                                                                                                                                  
  - Test03IbmFloats.scala: Updated expected value from 5.045883f → 322.93652f (the correct decoded value)     
