### PR TITLE
#855 Add COMP-1 and COMP-2 floating point encoders for the writer.

### DIFF
--- a/cobol-parser/src/main/scala/za/co/absa/cobrix/cobol/parser/antlr/ParserVisitor.scala
+++ b/cobol-parser/src/main/scala/za/co/absa/cobrix/cobol/parser/antlr/ParserVisitor.scala
@@ -862,7 +862,7 @@ class ParserVisitor(enc: Encoding,
       isFiller = identifier.toUpperCase() == Constants.FILLER,
       None,
       DecoderSelector.getDecoder(pic.value, stringTrimmingPolicy, isDisplayAlwaysString, effectiveEbcdicCodePage, effectiveAsciiCharset, isUtf16BigEndian = isUtf16BigEndian, floatingPointFormat, strictSignOverpunch = strictSignOverpunch, improvedNullDetection = improvedNullDetection, strictIntegralPrecision = strictIntegralPrecision),
-      EncoderSelector.getEncoder(pic.value, effectiveEbcdicCodePage, effectiveAsciiCharset)
+      EncoderSelector.getEncoder(pic.value, effectiveEbcdicCodePage, effectiveAsciiCharset, floatingPointFormat)
     )(Some(parent))
 
     parent.children.append(prim)

--- a/cobol-parser/src/main/scala/za/co/absa/cobrix/cobol/parser/encoding/EncoderSelector.scala
+++ b/cobol-parser/src/main/scala/za/co/absa/cobrix/cobol/parser/encoding/EncoderSelector.scala
@@ -16,8 +16,9 @@
 
 package za.co.absa.cobrix.cobol.parser.encoding
 
-import za.co.absa.cobrix.cobol.parser.ast.datatype.{AlphaNumeric, COMP3, COMP3U, COMP4, COMP9, CobolType, Decimal, Integral, Usage}
-import za.co.absa.cobrix.cobol.parser.decoders.BinaryUtils
+import za.co.absa.cobrix.cobol.parser.ast.datatype.{AlphaNumeric, COMP1, COMP2, COMP3, COMP3U, COMP4, COMP9, CobolType, Decimal, Integral, Usage}
+import za.co.absa.cobrix.cobol.parser.decoders.{BinaryUtils, FloatingPointFormat}
+import za.co.absa.cobrix.cobol.parser.decoders.FloatingPointFormat.FloatingPointFormat
 import za.co.absa.cobrix.cobol.parser.encoding.codepage.{CodePage, CodePageCommon}
 import za.co.absa.cobrix.cobol.parser.position.Position
 
@@ -29,7 +30,8 @@ object EncoderSelector {
 
   def getEncoder(dataType: CobolType,
                  ebcdicCodePage: CodePage = new CodePageCommon,
-                 asciiCharset: Charset = StandardCharsets.US_ASCII): Option[Encoder] = {
+                 asciiCharset: Charset = StandardCharsets.US_ASCII,
+                 floatingPointFormat: FloatingPointFormat = FloatingPointFormat.IBM): Option[Encoder] = {
     dataType match {
       case alphaNumeric: AlphaNumeric if alphaNumeric.compact.isEmpty                       =>
         getStringEncoder(alphaNumeric.enc.getOrElse(EBCDIC), ebcdicCodePage, asciiCharset, alphaNumeric.length)
@@ -53,6 +55,10 @@ object EncoderSelector {
         Option(getDisplayEncoder(integralDisplay.precision, 0, 0, integralDisplay.signPosition, isExplicitDecimalPt = false, isSignSeparate = integralDisplay.isSignSeparate))
       case decimalDisplay: Decimal if decimalDisplay.compact.isEmpty =>
         Option(getDisplayEncoder(decimalDisplay.precision, decimalDisplay.scale, decimalDisplay.scaleFactor, decimalDisplay.signPosition, decimalDisplay.explicitDecimal, decimalDisplay.isSignSeparate))
+      case decimalComp1: Decimal if decimalComp1.compact.exists(_.isInstanceOf[COMP1]) =>
+        Option(getSingleFloatingPointEncoder(floatingPointFormat))
+      case decimalComp2: Decimal if decimalComp2.compact.exists(_.isInstanceOf[COMP2]) =>
+        Option(getDoubleFloatingPointEncoder(floatingPointFormat))
       case _ =>
         None
     }
@@ -142,6 +148,52 @@ object EncoderSelector {
         DisplayEncoders.encodeDisplayNumberSignSeparate(number, signPosition, numBytes, precision, scale, scaleFactor, explicitDecimalPoint = isExplicitDecimalPt)
       } else {
         DisplayEncoders.encodeDisplayNumberSignOverpunched(number, signPosition, numBytes, precision, scale, scaleFactor, explicitDecimalPoint = isExplicitDecimalPt)
+      }
+    }
+  }
+
+  def getSingleFloatingPointEncoder(floatingPointFormat: FloatingPointFormat): Encoder = {
+    (a: Any) => {
+      val number: java.lang.Float = a match {
+        case null                    => 0f
+        case f: Float                => f
+        case d: Double               => d.toFloat
+        case d: java.math.BigDecimal => d.floatValue()
+        case n: java.math.BigInteger => new java.math.BigDecimal(n).floatValue()
+        case n: Byte                 => n.toFloat
+        case n: Int                  => n.toFloat
+        case n: Long                 => n.toFloat
+        case x                       => x.toString.toFloat
+      }
+
+      floatingPointFormat match {
+        case FloatingPointFormat.IBM        => FloatingPointEncoders.encodeIbmSingleBigEndian(number)
+        case FloatingPointFormat.IBM_LE     => FloatingPointEncoders.encodeIbmSingleLittleEndian(number)
+        case FloatingPointFormat.IEEE754    => FloatingPointEncoders.encodeIeee754SingleBigEndian(number)
+        case FloatingPointFormat.IEEE754_LE => FloatingPointEncoders.encodeIeee754SingleLittleEndian(number)
+      }
+    }
+  }
+
+  def getDoubleFloatingPointEncoder(floatingPointFormat: FloatingPointFormat): Encoder = {
+    (a: Any) => {
+      val number: java.lang.Double = a match {
+        case null                    => 0d
+        case f: Float                => f.toDouble
+        case d: Double               => d
+        case d: java.math.BigDecimal => d.doubleValue()
+        case n: java.math.BigInteger => new java.math.BigDecimal(n).doubleValue()
+        case n: Byte                 => n.toDouble
+        case n: Int                  => n.toDouble
+        case n: Long                 => n.toDouble
+        case x                       => x.toString.toFloat
+      }
+
+      floatingPointFormat match {
+        case FloatingPointFormat.IBM        => FloatingPointEncoders.encodeIbmDoubleBigEndian(number)
+        case FloatingPointFormat.IBM_LE     => FloatingPointEncoders.encodeIbmDoubleLittleEndian(number)
+        case FloatingPointFormat.IEEE754    => FloatingPointEncoders.encodeIeee754DoubleBigEndian(number)
+        case FloatingPointFormat.IEEE754_LE => FloatingPointEncoders.encodeIeee754DoubleLittleEndian(number)
       }
     }
   }

--- a/cobol-parser/src/main/scala/za/co/absa/cobrix/cobol/parser/encoding/EncoderSelector.scala
+++ b/cobol-parser/src/main/scala/za/co/absa/cobrix/cobol/parser/encoding/EncoderSelector.scala
@@ -17,13 +17,12 @@
 package za.co.absa.cobrix.cobol.parser.encoding
 
 import za.co.absa.cobrix.cobol.parser.ast.datatype.{AlphaNumeric, COMP1, COMP2, COMP3, COMP3U, COMP4, COMP9, CobolType, Decimal, Integral, Usage}
-import za.co.absa.cobrix.cobol.parser.decoders.{BinaryUtils, FloatingPointFormat}
 import za.co.absa.cobrix.cobol.parser.decoders.FloatingPointFormat.FloatingPointFormat
+import za.co.absa.cobrix.cobol.parser.decoders.{BinaryUtils, FloatingPointFormat}
 import za.co.absa.cobrix.cobol.parser.encoding.codepage.{CodePage, CodePageCommon}
 import za.co.absa.cobrix.cobol.parser.position.Position
 
 import java.nio.charset.{Charset, StandardCharsets}
-import java.util
 
 object EncoderSelector {
   type Encoder = Any => Array[Byte]
@@ -186,7 +185,7 @@ object EncoderSelector {
         case n: Byte                 => n.toDouble
         case n: Int                  => n.toDouble
         case n: Long                 => n.toDouble
-        case x                       => x.toString.toFloat
+        case x                       => x.toString.toDouble
       }
 
       floatingPointFormat match {

--- a/cobol-parser/src/main/scala/za/co/absa/cobrix/cobol/parser/encoding/FloatingPointEncoders.scala
+++ b/cobol-parser/src/main/scala/za/co/absa/cobrix/cobol/parser/encoding/FloatingPointEncoders.scala
@@ -1,0 +1,201 @@
+/*
+ * Copyright 2018 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.cobrix.cobol.parser.encoding
+
+import java.nio.{ByteBuffer, ByteOrder}
+
+object FloatingPointEncoders {
+  /**
+    * An encoder for IEEE-754 64 bit little-endian floats
+    *
+    * @param f A single precision floating point number.
+    * @return An array of 8 bytes representing the number.
+    */
+  def encodeIeee754SingleLittleEndian(f: Float): Array[Byte] = {
+    val byteBuffer = ByteBuffer.allocate(4)
+    byteBuffer.order(ByteOrder.LITTLE_ENDIAN)
+    byteBuffer.putFloat(f)
+    byteBuffer.array()
+  }
+
+  /**
+    * An encoder for IEEE-754 64 bit little-endian floats
+    *
+    * @param d A double precision floating point number.
+    * @return An array of 8 bytes representing the number.
+    */
+  def encodeIeee754DoubleLittleEndian(d: Double): Array[Byte] = {
+    val byteBuffer = ByteBuffer.allocate(8)
+    byteBuffer.order(ByteOrder.LITTLE_ENDIAN)
+    byteBuffer.putDouble(d)
+    byteBuffer.array()
+  }
+
+  /**
+    * An encoder for IEEE-754 64 bit big-endian floats
+    *
+    * @param f A single precision floating point number.
+    * @return An array of 8 bytes representing the number.
+    */
+  def encodeIeee754SingleBigEndian(f: Float): Array[Byte] = {
+    val byteBuffer = ByteBuffer.allocate(4)
+    byteBuffer.order(ByteOrder.BIG_ENDIAN)
+    byteBuffer.putFloat(f)
+    byteBuffer.array()
+  }
+
+  /**
+    * An encoder for IEEE-754 64 bit big-endian floats
+    *
+    * @param d A double precision floating point number.
+    * @return An array of 8 bytes representing the number.
+    */
+  def encodeIeee754DoubleBigEndian(d: Double): Array[Byte] = {
+    val byteBuffer = ByteBuffer.allocate(8)
+    byteBuffer.order(ByteOrder.BIG_ENDIAN)
+    byteBuffer.putDouble(d)
+    byteBuffer.array()
+  }
+
+  /**
+    * Encode a float into IBM single precision big endian format (4 bytes).
+    *
+    * IBM single precision hex float format:
+    *   - 1 bit sign
+    *   - 7 bits exponent (base-16, biased by 64)
+    *   - 24 bits fraction (normalized so that the high-order nibble is non-zero)
+    *
+    * @param f A single precision floating point number.
+    * @return An array of 4 bytes in IBM single precision big-endian format.
+    */
+  def encodeIbmSingleBigEndian(f: Float): Array[Byte] = {
+    if (f == 0.0f) {
+      return Array[Byte](0, 0, 0, 0)
+    }
+
+    if (f.isNaN) {
+      return Array[Byte](0xFF.toByte, 0xFF.toByte, 0xFF.toByte, 0xFF.toByte)
+    }
+
+    if (f.isInfinite) {
+      if (f > 0)
+        return Array[Byte](0x7F.toByte, 0xFF.toByte, 0xFF.toByte, 0xFF.toByte)
+      else
+        return Array[Byte](0xFF.toByte, 0xFF.toByte, 0xFF.toByte, 0xFF.toByte)
+    }
+
+    val sign: Int = if (f < 0) 0x80 else 0x00
+    var absVal = Math.abs(f).toDouble
+
+    // Determine the base-16 exponent
+    var exp16 = 0
+    if (absVal >= 1.0) {
+      while (absVal >= 1.0) {
+        absVal /= 16.0
+        exp16 += 1
+      }
+    } else {
+      while (absVal < (1.0 / 16.0)) {
+        absVal *= 16.0
+        exp16 -= 1
+      }
+    }
+
+    val biasedExp = exp16 + 64
+
+    // fraction is in [1/16, 1), scale to 24-bit integer
+    val fracInt = (absVal * (1 << 24)).toLong & 0xFFFFFFL
+
+    val b0 = (sign | (biasedExp & 0x7F)).toByte
+    val b1 = ((fracInt >> 16) & 0xFF).toByte
+    val b2 = ((fracInt >> 8) & 0xFF).toByte
+    val b3 = (fracInt & 0xFF).toByte
+
+    Array(b0, b1, b2, b3)
+  }
+
+  /**
+    * Encode a double into IBM double precision big endian format (8 bytes).
+    *
+    * IBM double precision hex float format:
+    *   - 1 bit sign
+    *   - 7 bits exponent (base-16, biased by 64)
+    *   - 56 bits fraction (normalized so that the high-order nibble is non-zero)
+    *
+    * @param d A double precision floating point number.
+    * @return An array of 8 bytes in IBM double precision big-endian format.
+    */
+  def encodeIbmDoubleBigEndian(d: Double): Array[Byte] = {
+    if (d == 0.0) {
+      return Array[Byte](0, 0, 0, 0, 0, 0, 0, 0)
+    }
+
+    if (d.isNaN) {
+      return Array[Byte](0xFF.toByte, 0xFF.toByte, 0xFF.toByte, 0xFF.toByte, 0xFF.toByte, 0xFF.toByte, 0xFF.toByte, 0xFF.toByte)
+    }
+
+    if (d.isInfinite) {
+      if (d > 0)
+        return Array[Byte](0x7F.toByte, 0xFF.toByte, 0xFF.toByte, 0xFF.toByte, 0xFF.toByte, 0xFF.toByte, 0xFF.toByte, 0xFF.toByte)
+      else
+        return Array[Byte](0xFF.toByte, 0xFF.toByte, 0xFF.toByte, 0xFF.toByte, 0xFF.toByte, 0xFF.toByte, 0xFF.toByte, 0xFF.toByte)
+    }
+
+    val sign: Int = if (d < 0) 0x80 else 0x00
+    var absVal = Math.abs(d)
+
+    // Determine the base-16 exponent
+    var exp16 = 0
+    if (absVal >= 1.0) {
+      while (absVal >= 1.0) {
+        absVal /= 16.0
+        exp16 += 1
+      }
+    } else {
+      while (absVal < (1.0 / 16.0)) {
+        absVal *= 16.0
+        exp16 -= 1
+      }
+    }
+
+    val biasedExp = exp16 + 64
+
+    // fraction is in [1/16, 1), scale to 56-bit integer
+    val fracLong = (absVal * (1L << 56).toDouble).toLong & 0x00FFFFFFFFFFFFFFL
+
+    val b0 = (sign | (biasedExp & 0x7F)).toByte
+    val b1 = ((fracLong >> 48) & 0xFF).toByte
+    val b2 = ((fracLong >> 40) & 0xFF).toByte
+    val b3 = ((fracLong >> 32) & 0xFF).toByte
+    val b4 = ((fracLong >> 24) & 0xFF).toByte
+    val b5 = ((fracLong >> 16) & 0xFF).toByte
+    val b6 = ((fracLong >> 8) & 0xFF).toByte
+    val b7 = (fracLong & 0xFF).toByte
+
+    Array(b0, b1, b2, b3, b4, b5, b6, b7)
+  }
+
+  /** Encode a float into IBM single precision little endian format (4 bytes). */
+  def encodeIbmSingleLittleEndian(f: Float): Array[Byte] = {
+    encodeIbmSingleBigEndian(f).reverse
+  }
+
+  /** Encode a double into IBM double precision little endian format (8 bytes). */
+  def encodeIbmDoubleLittleEndian(d: Double): Array[Byte] = {
+    encodeIbmDoubleBigEndian(d).reverse
+  }
+}

--- a/cobol-parser/src/test/scala/za/co/absa/cobrix/cobol/parser/encoding/FloatingPointEncodersSuite.scala
+++ b/cobol-parser/src/test/scala/za/co/absa/cobrix/cobol/parser/encoding/FloatingPointEncodersSuite.scala
@@ -1,0 +1,388 @@
+/*
+ * Copyright 2018 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.cobrix.cobol.parser.encoding
+
+import org.scalatest.wordspec.AnyWordSpec
+import za.co.absa.cobrix.cobol.parser.decoders.FloatingPointDecoders
+
+import java.nio.{ByteBuffer, ByteOrder}
+
+class FloatingPointEncodersSuite extends AnyWordSpec {
+  private def floatToBigEndianBytes(f: Float): Array[Byte] = {
+    val buf = ByteBuffer.allocate(4).order(ByteOrder.BIG_ENDIAN)
+    buf.putFloat(f)
+    buf.array()
+  }
+
+  private def floatToLittleEndianBytes(f: Float): Array[Byte] = {
+    val buf = ByteBuffer.allocate(4).order(ByteOrder.LITTLE_ENDIAN)
+    buf.putFloat(f)
+    buf.array()
+  }
+
+  private def doubleToBigEndianBytes(d: Double): Array[Byte] = {
+    val buf = ByteBuffer.allocate(8).order(ByteOrder.BIG_ENDIAN)
+    buf.putDouble(d)
+    buf.array()
+  }
+
+  private def doubleToLittleEndianBytes(d: Double): Array[Byte] = {
+    val buf = ByteBuffer.allocate(8).order(ByteOrder.LITTLE_ENDIAN)
+    buf.putDouble(d)
+    buf.array()
+  }
+
+  "encodeIeee754SingleBigEndian" should {
+    "encode 0.0f" in {
+      val result = FloatingPointEncoders.encodeIeee754SingleBigEndian(0.0f)
+      assert(result.length == 4)
+      assert(result.sameElements(Array(0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte)))
+    }
+
+    "encode 1.0f" in {
+      val result = FloatingPointEncoders.encodeIeee754SingleBigEndian(1.0f)
+      assert(result.sameElements(Array(0x3F.toByte, 0x80.toByte, 0x00.toByte, 0x00.toByte)))
+    }
+
+    "encode -1.0f" in {
+      val result = FloatingPointEncoders.encodeIeee754SingleBigEndian(-1.0f)
+      assert(result.sameElements(Array(0xBF.toByte, 0x80.toByte, 0x00.toByte, 0x00.toByte)))
+    }
+
+    "encode positive infinity" in {
+      val result = FloatingPointEncoders.encodeIeee754SingleBigEndian(Float.PositiveInfinity)
+      assert(result.sameElements(Array(0x7F.toByte, 0x80.toByte, 0x00.toByte, 0x00.toByte)))
+    }
+
+    "encode negative infinity" in {
+      val result = FloatingPointEncoders.encodeIeee754SingleBigEndian(Float.NegativeInfinity)
+      assert(result.sameElements(Array(0xFF.toByte, 0x80.toByte, 0x00.toByte, 0x00.toByte)))
+    }
+
+    "encode NaN" in {
+      val result = FloatingPointEncoders.encodeIeee754SingleBigEndian(Float.NaN)
+      assert(result.sameElements(floatToBigEndianBytes(Float.NaN)))
+    }
+
+    "round-trip with decode" in {
+      val original = 3.14f
+      val encoded = FloatingPointEncoders.encodeIeee754SingleBigEndian(original)
+      val decoded = FloatingPointDecoders.decodeFloatB(encoded)
+      assert(decoded == original)
+    }
+
+    "encode Float.MaxValue" in {
+      val result = FloatingPointEncoders.encodeIeee754SingleBigEndian(Float.MaxValue)
+      assert(result.sameElements(floatToBigEndianBytes(Float.MaxValue)))
+    }
+
+    "encode Float.MinPositiveValue" in {
+      val result = FloatingPointEncoders.encodeIeee754SingleBigEndian(Float.MinPositiveValue)
+      assert(result.sameElements(Array(0x00.toByte, 0x00.toByte, 0x00.toByte, 0x01.toByte)))
+    }
+  }
+
+  "encodeIeee754SingleLittleEndian" should {
+    "encode 0.0f" in {
+      val result = FloatingPointEncoders.encodeIeee754SingleLittleEndian(0.0f)
+      assert(result.length == 4)
+      assert(result.sameElements(Array(0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte)))
+    }
+
+    "encode 1.0f" in {
+      val result = FloatingPointEncoders.encodeIeee754SingleLittleEndian(1.0f)
+      assert(result.sameElements(Array(0x00.toByte, 0x00.toByte, 0x80.toByte, 0x3F.toByte)))
+    }
+
+    "encode -1.0f" in {
+      val result = FloatingPointEncoders.encodeIeee754SingleLittleEndian(-1.0f)
+      assert(result.sameElements(Array(0x00.toByte, 0x00.toByte, 0x80.toByte, 0xBF.toByte)))
+    }
+
+    "round-trip with decode" in {
+      val original = -2.718f
+      val encoded = FloatingPointEncoders.encodeIeee754SingleLittleEndian(original)
+      val decoded = FloatingPointDecoders.decodeFloatL(encoded)
+      assert(decoded == original)
+    }
+
+    "encode positive infinity" in {
+      val result = FloatingPointEncoders.encodeIeee754SingleLittleEndian(Float.PositiveInfinity)
+      assert(result.sameElements(floatToLittleEndianBytes(Float.PositiveInfinity)))
+    }
+
+    "encode negative infinity" in {
+      val result = FloatingPointEncoders.encodeIeee754SingleLittleEndian(Float.NegativeInfinity)
+      assert(result.sameElements(floatToLittleEndianBytes(Float.NegativeInfinity)))
+    }
+  }
+
+  "encodeIeee754DoubleBigEndian" should {
+    "encode 0.0" in {
+      val result = FloatingPointEncoders.encodeIeee754DoubleBigEndian(0.0)
+      assert(result.length == 8)
+      assert(result.sameElements(Array(0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte)))
+    }
+
+    "encode 1.0" in {
+      val result = FloatingPointEncoders.encodeIeee754DoubleBigEndian(1.0)
+      assert(result.sameElements(Array(0x3F.toByte, 0xF0.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte)))
+    }
+
+    "encode -1.0" in {
+      val result = FloatingPointEncoders.encodeIeee754DoubleBigEndian(-1.0)
+      assert(result.sameElements(Array(0xBF.toByte, 0xF0.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte)))
+    }
+
+    "encode positive infinity" in {
+      val result = FloatingPointEncoders.encodeIeee754DoubleBigEndian(Double.PositiveInfinity)
+      assert(result.sameElements(Array(0x7F.toByte, 0xF0.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte)))
+    }
+
+    "encode negative infinity" in {
+      val result = FloatingPointEncoders.encodeIeee754DoubleBigEndian(Double.NegativeInfinity)
+      assert(result.sameElements(Array(0xFF.toByte, 0xF0.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte)))
+    }
+
+    "encode NaN" in {
+      val result = FloatingPointEncoders.encodeIeee754DoubleBigEndian(Double.NaN)
+      assert(result.sameElements(doubleToBigEndianBytes(Double.NaN)))
+    }
+
+    "round-trip with decode" in {
+      val original = 3.141592653589793
+      val encoded = FloatingPointEncoders.encodeIeee754DoubleBigEndian(original)
+      val decoded = FloatingPointDecoders.decodeDoubleB(encoded)
+      assert(decoded == original)
+    }
+
+    "encode Double.MaxValue" in {
+      val result = FloatingPointEncoders.encodeIeee754DoubleBigEndian(Double.MaxValue)
+      assert(result.sameElements(doubleToBigEndianBytes(Double.MaxValue)))
+    }
+
+    "encode Double.MinPositiveValue" in {
+      val result = FloatingPointEncoders.encodeIeee754DoubleBigEndian(Double.MinPositiveValue)
+      assert(result.sameElements(doubleToBigEndianBytes(Double.MinPositiveValue)))
+    }
+  }
+
+  "encodeIeee754DoubleLittleEndian" should {
+    "encode 0.0" in {
+      val result = FloatingPointEncoders.encodeIeee754DoubleLittleEndian(0.0)
+      assert(result.length == 8)
+      assert(result.sameElements(Array(0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte)))
+    }
+
+    "encode 1.0" in {
+      val result = FloatingPointEncoders.encodeIeee754DoubleLittleEndian(1.0)
+      assert(result.sameElements(Array(0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0xF0.toByte, 0x3F.toByte)))
+    }
+
+    "encode -1.0" in {
+      val result = FloatingPointEncoders.encodeIeee754DoubleLittleEndian(-1.0)
+      assert(result.sameElements(Array(0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0xF0.toByte, 0xBF.toByte)))
+    }
+
+    "round-trip with decode" in {
+      val original = -2.718281828459045
+      val encoded = FloatingPointEncoders.encodeIeee754DoubleLittleEndian(original)
+      val decoded = FloatingPointDecoders.decodeDoubleL(encoded)
+      assert(decoded == original)
+    }
+
+    "encode positive infinity" in {
+      val result = FloatingPointEncoders.encodeIeee754DoubleLittleEndian(Double.PositiveInfinity)
+      assert(result.sameElements(doubleToLittleEndianBytes(Double.PositiveInfinity)))
+    }
+
+    "encode negative infinity" in {
+      val result = FloatingPointEncoders.encodeIeee754DoubleLittleEndian(Double.NegativeInfinity)
+      assert(result.sameElements(doubleToLittleEndianBytes(Double.NegativeInfinity)))
+    }
+  }
+
+  "encodeIbmSingleBigEndian" should {
+    "encode 0.0f as all zeros" in {
+      val result = FloatingPointEncoders.encodeIbmSingleBigEndian(0.0f)
+      assert(result.length == 4)
+      assert(result.sameElements(Array[Byte](0, 0, 0, 0)))
+    }
+
+    "encode NaN as all 0xFF bytes" in {
+      val result = FloatingPointEncoders.encodeIbmSingleBigEndian(Float.NaN)
+      assert(result.sameElements(Array[Byte](0xFF.toByte, 0xFF.toByte, 0xFF.toByte, 0xFF.toByte)))
+    }
+
+    "encode positive infinity as 0x7FFFFFFF" in {
+      val result = FloatingPointEncoders.encodeIbmSingleBigEndian(Float.PositiveInfinity)
+      assert(result.sameElements(Array[Byte](0x7F.toByte, 0xFF.toByte, 0xFF.toByte, 0xFF.toByte)))
+    }
+
+    "encode negative infinity as all 0xFF bytes" in {
+      val result = FloatingPointEncoders.encodeIbmSingleBigEndian(Float.NegativeInfinity)
+      assert(result.sameElements(Array[Byte](0xFF.toByte, 0xFF.toByte, 0xFF.toByte, 0xFF.toByte)))
+    }
+
+    "encode 1.0f correctly" in {
+      // 1.0 in IBM single: sign=0, exp=65 (0x41), fraction = 0.1 hex = 0x100000
+      val result = FloatingPointEncoders.encodeIbmSingleBigEndian(1.0f)
+      assert(result(0) == 0x41.toByte)
+      assert(result(1) == 0x10.toByte)
+      assert(result(2) == 0x00.toByte)
+      assert(result(3) == 0x00.toByte)
+    }
+
+    "encode -1.0f with sign bit set" in {
+      val result = FloatingPointEncoders.encodeIbmSingleBigEndian(-1.0f)
+      assert((result(0) & 0x80) != 0) // sign bit set
+      assert((result(0) & 0x7F) == 0x41) // exponent same as positive
+    }
+
+    "encode 0.5f correctly" in {
+      // 0.5 in IBM single: sign=0, exp=64 (0x40), fraction = 0.8 hex = 0x800000
+      val result = FloatingPointEncoders.encodeIbmSingleBigEndian(0.5f)
+      assert(result(0) == 0x40.toByte)
+      assert(result(1) == 0x80.toByte)
+      assert(result(2) == 0x00.toByte)
+      assert(result(3) == 0x00.toByte)
+    }
+
+    "encode 16.0f correctly" in {
+      // 16.0 in IBM single: sign=0, exp=66 (0x42), fraction = 0.1 hex = 0x100000
+      val result = FloatingPointEncoders.encodeIbmSingleBigEndian(16.0f)
+      assert(result(0) == 0x42.toByte)
+      assert(result(1) == 0x10.toByte)
+      assert(result(2) == 0x00.toByte)
+      assert(result(3) == 0x00.toByte)
+    }
+
+    "produce 4 bytes output" in {
+      val result = FloatingPointEncoders.encodeIbmSingleBigEndian(42.0f)
+      assert(result.length == 4)
+    }
+  }
+
+  "encodeIbmDoubleBigEndian" should {
+    "encode 0.0 as all zeros" in {
+      val result = FloatingPointEncoders.encodeIbmDoubleBigEndian(0.0)
+      assert(result.length == 8)
+      assert(result.sameElements(Array[Byte](0, 0, 0, 0, 0, 0, 0, 0)))
+    }
+
+    "encode NaN as all 0xFF bytes" in {
+      val result = FloatingPointEncoders.encodeIbmDoubleBigEndian(Double.NaN)
+      assert(result.sameElements(Array[Byte](0xFF.toByte, 0xFF.toByte, 0xFF.toByte, 0xFF.toByte, 0xFF.toByte, 0xFF.toByte, 0xFF.toByte, 0xFF.toByte)))
+    }
+
+    "encode positive infinity as 0x7FFFFFFFFFFFFFFF" in {
+      val result = FloatingPointEncoders.encodeIbmDoubleBigEndian(Double.PositiveInfinity)
+      assert(result.sameElements(Array[Byte](0x7F.toByte, 0xFF.toByte, 0xFF.toByte, 0xFF.toByte, 0xFF.toByte, 0xFF.toByte, 0xFF.toByte, 0xFF.toByte)))
+    }
+
+    "encode negative infinity as all 0xFF bytes" in {
+      val result = FloatingPointEncoders.encodeIbmDoubleBigEndian(Double.NegativeInfinity)
+      assert(result.sameElements(Array[Byte](0xFF.toByte, 0xFF.toByte, 0xFF.toByte, 0xFF.toByte, 0xFF.toByte, 0xFF.toByte, 0xFF.toByte, 0xFF.toByte)))
+    }
+
+    "encode 1.0 correctly" in {
+      // 1.0 in IBM double: sign=0, exp=65 (0x41), fraction starts with 0x10...
+      val result = FloatingPointEncoders.encodeIbmDoubleBigEndian(1.0)
+      assert(result(0) == 0x41.toByte)
+      assert(result(1) == 0x10.toByte)
+      assert(result(2) == 0x00.toByte)
+      assert(result(3) == 0x00.toByte)
+      assert(result(4) == 0x00.toByte)
+      assert(result(5) == 0x00.toByte)
+      assert(result(6) == 0x00.toByte)
+      assert(result(7) == 0x00.toByte)
+    }
+
+    "encode -1.0 with sign bit set" in {
+      val result = FloatingPointEncoders.encodeIbmDoubleBigEndian(-1.0)
+      assert((result(0) & 0x80) != 0) // sign bit set
+      assert((result(0) & 0x7F) == 0x41) // exponent same as positive
+    }
+
+    "encode 0.5 correctly" in {
+      // 0.5 in IBM double: sign=0, exp=64 (0x40), fraction = 0x80...
+      val result = FloatingPointEncoders.encodeIbmDoubleBigEndian(0.5)
+      assert(result(0) == 0x40.toByte)
+      assert(result(1) == 0x80.toByte)
+      // remaining bytes should be 0
+      assert(result(2) == 0x00.toByte)
+      assert(result(3) == 0x00.toByte)
+      assert(result(4) == 0x00.toByte)
+      assert(result(5) == 0x00.toByte)
+      assert(result(6) == 0x00.toByte)
+      assert(result(7) == 0x00.toByte)
+    }
+
+    "produce 8 bytes output" in {
+      val result = FloatingPointEncoders.encodeIbmDoubleBigEndian(42.0)
+      assert(result.length == 8)
+    }
+  }
+
+  "encodeIbmSingleLittleEndian" should {
+    "encode 0.0f as all zeros" in {
+      val result = FloatingPointEncoders.encodeIbmSingleLittleEndian(0.0f)
+      assert(result.sameElements(Array[Byte](0, 0, 0, 0)))
+    }
+
+    "be the reverse of big-endian encoding" in {
+      val bigEndian = FloatingPointEncoders.encodeIbmSingleBigEndian(1.0f)
+      val littleEndian = FloatingPointEncoders.encodeIbmSingleLittleEndian(1.0f)
+      assert(littleEndian.sameElements(bigEndian.reverse))
+    }
+
+    "be the reverse of big-endian encoding for negative values" in {
+      val bigEndian = FloatingPointEncoders.encodeIbmSingleBigEndian(-3.14f)
+      val littleEndian = FloatingPointEncoders.encodeIbmSingleLittleEndian(-3.14f)
+      assert(littleEndian.sameElements(bigEndian.reverse))
+    }
+
+    "produce 4 bytes output" in {
+      val result = FloatingPointEncoders.encodeIbmSingleLittleEndian(42.0f)
+      assert(result.length == 4)
+    }
+  }
+
+  "encodeIbmDoubleLittleEndian" should {
+    "encode 0.0 as all zeros" in {
+      val result = FloatingPointEncoders.encodeIbmDoubleLittleEndian(0.0)
+      assert(result.sameElements(Array[Byte](0, 0, 0, 0, 0, 0, 0, 0)))
+    }
+
+    "be the reverse of big-endian encoding" in {
+      val bigEndian = FloatingPointEncoders.encodeIbmDoubleBigEndian(1.0)
+      val littleEndian = FloatingPointEncoders.encodeIbmDoubleLittleEndian(1.0)
+      assert(littleEndian.sameElements(bigEndian.reverse))
+    }
+
+    "be the reverse of big-endian encoding for negative values" in {
+      val bigEndian = FloatingPointEncoders.encodeIbmDoubleBigEndian(-3.141592653589793)
+      val littleEndian = FloatingPointEncoders.encodeIbmDoubleLittleEndian(-3.141592653589793)
+      assert(littleEndian.sameElements(bigEndian.reverse))
+    }
+
+    "produce 8 bytes output" in {
+      val result = FloatingPointEncoders.encodeIbmDoubleLittleEndian(42.0)
+      assert(result.length == 8)
+    }
+  }
+}

--- a/spark-cobol/src/test/scala/za/co/absa/cobrix/spark/cobol/writer/FixedLengthEbcdicWriterSuite.scala
+++ b/spark-cobol/src/test/scala/za/co/absa/cobrix/spark/cobol/writer/FixedLengthEbcdicWriterSuite.scala
@@ -497,6 +497,339 @@ class FixedLengthEbcdicWriterSuite extends AnyWordSpec with SparkTestBase with B
     }
   }
 
+
+  "write data frames with COMP-1 and COMP-2 fields" should {
+    val copybookWithComp12 =
+      """       01  RECORD.
+           05  A       PIC S9(1)      COMP.
+           05  B       PIC 9(4)V9(2)  COMP-1.
+           05  C       PIC 9(4)V9(4)  COMP-2.
+    """
+
+    val df = List[(Int, java.lang.Float, java.lang.Double)](
+      (1, 100.5f, 100.5),
+      (2, 800.4f, 800.4),
+      (3, -22.33f, -22.33),
+      (4, 0f, 0.0),
+      (5, Float.PositiveInfinity, Double.PositiveInfinity),
+      (6, Float.NegativeInfinity, Double.NegativeInfinity),
+      (7, Float.NaN, Double.NaN),
+      (8, null: java.lang.Float, null: java.lang.Double)
+    ).toDF("A", "B", "C")
+
+    "IEE754 Little-endian" in {
+      withTempDirectory("cobol_writer1") { tempDir =>
+        val path = new Path(tempDir, "writer1")
+
+        df.coalesce(1)
+          .orderBy("A")
+          .write
+          .format("cobol")
+          .mode(SaveMode.Overwrite)
+          .option("copybook_contents", copybookWithComp12)
+          .option("floating_point_format", "IEEE754_little_endian")
+          .save(path.toString)
+
+        val fs = path.getFileSystem(spark.sparkContext.hadoopConfiguration)
+
+        assert(fs.exists(path), "Output directory should exist")
+        val files = fs.listStatus(path)
+          .filter(_.getPath.getName.startsWith("part-"))
+
+        assert(files.nonEmpty, "Output directory should contain part files")
+
+        val partFile = files.head.getPath
+        val data = fs.open(partFile)
+        val bytes = new Array[Byte](files.head.getLen.toInt)
+        data.readFully(bytes)
+        data.close()
+
+        // Expected EBCDIC data for sample test data
+        val expected = Array(
+          0x00, 0x01,                                      // 1
+          0x00, 0x00, 0xC9, 0x42,                          // 100.5f
+          0x00, 0x00, 0x00, 0x00, 0x00, 0x20, 0x59, 0x40,  // 100.5d
+
+          0x00, 0x02,                                      // 2
+          0x9A, 0x19, 0x48, 0x44,                          // 800.4f
+          0x33, 0x33, 0x33, 0x33, 0x33, 0x03, 0x89, 0x40,  // 800.4fd
+
+          0x00, 0x03,                                      // 3
+          0xD7, 0xA3, 0xB2, 0xC1,                          // -22.33f
+          0x14, 0xAE, 0x47, 0xE1, 0x7A, 0x54, 0x36, 0xC0,  // -22.33d
+
+          0x00, 0x04,                                      // 4
+          0x00, 0x00, 0x00, 0x00,                          // 0
+          0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,  // 0
+
+          0x00, 0x05,                                      // 5
+          0x00, 0x00, 0x80, 0x7F,                          // +inf
+          0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xF0, 0x7F,  // +inf
+
+          0x00, 0x06,                                      // 6
+          0x00, 0x00, 0x80, 0xFF,                          // -inf
+          0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xF0, 0xFF,  // -inf
+
+          0x00, 0x07,                                      // 7
+          0x00, 0x00, 0xC0, 0x7F,                          // NaN
+          0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xF8, 0x7F,  // NaN
+
+          0x00, 0x08,                                      // 8
+          0x00, 0x00, 0x00, 0x00,                          // null
+          0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00   // null
+        ).map(_.toByte)
+
+//         val df2 = spark.read.format("cobol")
+//           .option("copybook_contents", copybookWithComp12)
+//           .option("floating_point_format", "IEEE754_little_endian")
+//           .load(path.toString)
+//         //println(SparkUtils.convertDataFrameToPrettyJSON(df2))
+//        df2.show(false)
+
+        if (!bytes.sameElements(expected)) {
+          println(s"Expected bytes: ${expected.map("0x%02X," format _).mkString(" ")}")
+          println(s"Actual bytes:   ${bytes.map("0x%02X," format _).mkString(" ")}")
+
+          assert(bytes.sameElements(expected), "Written data should match expected EBCDIC encoding")
+        }
+      }
+    }
+
+    "IEE754 Big-endian" in {
+      withTempDirectory("cobol_writer1") { tempDir =>
+        val path = new Path(tempDir, "writer1")
+
+        df.coalesce(1)
+          .orderBy("A")
+          .write
+          .format("cobol")
+          .mode(SaveMode.Overwrite)
+          .option("copybook_contents", copybookWithComp12)
+          .option("floating_point_format", "IEEE754")
+          .save(path.toString)
+
+        val fs = path.getFileSystem(spark.sparkContext.hadoopConfiguration)
+
+        assert(fs.exists(path), "Output directory should exist")
+        val files = fs.listStatus(path)
+          .filter(_.getPath.getName.startsWith("part-"))
+
+        assert(files.nonEmpty, "Output directory should contain part files")
+
+        val partFile = files.head.getPath
+        val data = fs.open(partFile)
+        val bytes = new Array[Byte](files.head.getLen.toInt)
+        data.readFully(bytes)
+        data.close()
+
+        // Expected EBCDIC data for sample test data
+        val expected = Array(
+          0x00, 0x01,                                      // 1
+          0x42, 0xC9, 0x00, 0x00,                          // 100.5f
+          0x40, 0x59, 0x20, 0x00, 0x00, 0x00, 0x00, 0x00,  // 100.5d
+
+          0x00, 0x02,                                      // 2
+          0x44, 0x48, 0x19, 0x9A,                          // 800.4f
+          0x40, 0x89, 0x03, 0x33, 0x33, 0x33, 0x33, 0x33,  // 800.4fd
+
+          0x00, 0x03,                                      // 3
+          0xC1, 0xB2, 0xA3, 0xD7,                          // -22.33f
+          0xC0, 0x36, 0x54, 0x7A, 0xE1, 0x47, 0xAE, 0x14,  // -22.33d
+
+          0x00, 0x04,                                      // 4
+          0x00, 0x00, 0x00, 0x00,                          // 0
+          0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,  // 0
+
+          0x00, 0x05,                                      // 5
+          0x7F, 0x80, 0x00, 0x00,                          // +inf
+          0x7F, 0xF0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,  // +inf
+
+          0x00, 0x06,                                      // 6
+          0xFF, 0x80, 0x00, 0x00,                          // -inf
+          0xFF, 0xF0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,  // -inf
+
+          0x00, 0x07,                                      // 7
+          0x7F, 0xC0, 0x00, 0x00,                          // NaN
+          0x7F, 0xF8, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,  // NaN
+
+          0x00, 0x08,                                      // 8
+          0x00, 0x00, 0x00, 0x00,                          // null
+          0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00   // null
+        ).map(_.toByte)
+
+//        val df2 = spark.read.format("cobol")
+//          .option("copybook_contents", copybookWithComp12)
+//          .option("floating_point_format", "IEEE754")
+//          .load(path.toString)
+//        //println(SparkUtils.convertDataFrameToPrettyJSON(df2))
+//        df2.show(false)
+
+        if (!bytes.sameElements(expected)) {
+          println(s"Expected bytes: ${expected.map("0x%02X," format _).mkString(" ")}")
+          println(s"Actual bytes:   ${bytes.map("0x%02X," format _).mkString(" ")}")
+
+          assert(bytes.sameElements(expected), "Written data should match expected EBCDIC encoding")
+        }
+      }
+    }
+
+    "IBM Little-endian" in {
+      withTempDirectory("cobol_writer1") { tempDir =>
+        val path = new Path(tempDir, "writer1")
+
+        df.coalesce(1)
+          .orderBy("A")
+          .write
+          .format("cobol")
+          .mode(SaveMode.Overwrite)
+          .option("copybook_contents", copybookWithComp12)
+          .option("floating_point_format", "IBM_little_endian")
+          .save(path.toString)
+
+        val fs = path.getFileSystem(spark.sparkContext.hadoopConfiguration)
+
+        assert(fs.exists(path), "Output directory should exist")
+        val files = fs.listStatus(path)
+          .filter(_.getPath.getName.startsWith("part-"))
+
+        assert(files.nonEmpty, "Output directory should contain part files")
+
+        val partFile = files.head.getPath
+        val data = fs.open(partFile)
+        val bytes = new Array[Byte](files.head.getLen.toInt)
+        data.readFully(bytes)
+        data.close()
+
+        // Expected EBCDIC data for sample test data
+        val expected = Array(
+          0x00, 0x01,                                      // 1
+          0x00, 0x80, 0x64, 0x42,                          // 100.5f
+          0x00, 0x00, 0x00, 0x00, 0x00, 0x80, 0x64, 0x42,  // 100.5d
+
+          0x00, 0x02,                                      // 2
+          0x66, 0x06, 0x32, 0x43,                          // 800.4f
+          0x66, 0x66, 0x66, 0x66, 0x66, 0x06, 0x32, 0x43,  // 800.4fd
+
+          0x00, 0x03,                                      // 3
+          0x7A, 0x54, 0x16, 0xC2,                          // -22.33f
+          0x14, 0xAE, 0x47, 0xE1, 0x7A, 0x54, 0x16, 0xC2,  // -22.33d
+
+          0x00, 0x04,                                      // 4
+          0x00, 0x00, 0x00, 0x00,                          // 0
+          0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,  // 0
+
+          0x00, 0x05,                                      // 5
+          0xFF, 0xFF, 0xFF, 0x7F,                          // +inf
+          0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x7F,  // +inf
+
+          0x00, 0x06,                                      // 7
+          0xFF, 0xFF, 0xFF, 0xFF,                          // -inf
+          0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,  // -inf
+
+          0x00, 0x07,                                      // 8
+          0xFF, 0xFF, 0xFF, 0xFF,                          // NaN
+          0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,  // NaN
+
+          0x00, 0x08,                                      // 8
+          0x00, 0x00, 0x00, 0x00,                          // null
+          0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00   // null
+        ).map(_.toByte)
+
+//        val df2 = spark.read.format("cobol")
+//          .option("copybook_contents", copybookWithComp12)
+//          .option("floating_point_format", "IBM_little_endian")
+//          .load(path.toString)
+//        //println(SparkUtils.convertDataFrameToPrettyJSON(df2))
+//        df2.show(false)
+
+        if (!bytes.sameElements(expected)) {
+          println(s"Expected bytes: ${expected.map("0x%02X," format _).mkString(" ")}")
+          println(s"Actual bytes:   ${bytes.map("0x%02X," format _).mkString(" ")}")
+
+          assert(bytes.sameElements(expected), "Written data should match expected EBCDIC encoding")
+        }
+      }
+    }
+
+    "IBM Big-endian" in {
+      withTempDirectory("cobol_writer1") { tempDir =>
+        val path = new Path(tempDir, "writer1")
+
+        df.coalesce(1)
+          .orderBy("A")
+          .write
+          .format("cobol")
+          .mode(SaveMode.Overwrite)
+          .option("copybook_contents", copybookWithComp12)
+          .option("floating_point_format", "IBM")
+          .save(path.toString)
+
+        val fs = path.getFileSystem(spark.sparkContext.hadoopConfiguration)
+
+        assert(fs.exists(path), "Output directory should exist")
+        val files = fs.listStatus(path)
+          .filter(_.getPath.getName.startsWith("part-"))
+
+        assert(files.nonEmpty, "Output directory should contain part files")
+
+        val partFile = files.head.getPath
+        val data = fs.open(partFile)
+        val bytes = new Array[Byte](files.head.getLen.toInt)
+        data.readFully(bytes)
+        data.close()
+
+        // Expected EBCDIC data for sample test data
+        val expected = Array(
+          0x00, 0x01,                                      // 1
+          0x42, 0x64, 0x80, 0x00,                          // 100.5f
+          0x42, 0x64, 0x80, 0x00, 0x00, 0x00, 0x00, 0x00,  // 100.5d
+
+          0x00, 0x02,                                      // 2
+          0x43, 0x32, 0x06, 0x66,                          // 800.4f
+          0x43, 0x32, 0x06, 0x66, 0x66, 0x66, 0x66, 0x66,  // 800.4fd
+
+          0x00, 0x03,                                      // 3
+          0xC2, 0x16, 0x54, 0x7A,                          // -22.33f
+          0xC2, 0x16, 0x54, 0x7A, 0xE1, 0x47, 0xAE, 0x14,  // -22.33d
+
+          0x00, 0x04,                                      // 4
+          0x00, 0x00, 0x00, 0x00,                          // 0
+          0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,  // 0
+
+          0x00, 0x05,                                      // 5
+          0x7F, 0xFF, 0xFF, 0xFF,                          // +inf
+          0x7F, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,  // +inf
+
+          0x00, 0x06,                                      // 6
+          0xFF, 0xFF, 0xFF, 0xFF,                          // -inf
+          0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,  // -inf
+
+          0x00, 0x07,                                      // 7
+          0xFF, 0xFF, 0xFF, 0xFF,                          // NaN
+          0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,  // NaN
+
+          0x00, 0x08,                                      // 8
+          0x00, 0x00, 0x00, 0x00,                          // null
+          0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00   // null
+        ).map(_.toByte)
+
+//        val df2 = spark.read.format("cobol")
+//          .option("copybook_contents", copybookWithComp12)
+//          .option("floating_point_format", "IBM")
+//          .load(path.toString)
+//        //println(SparkUtils.convertDataFrameToPrettyJSON(df2))
+//       df2.show(false)
+
+        if (!bytes.sameElements(expected)) {
+          println(s"Expected bytes: ${expected.map("0x%02X," format _).mkString(" ")}")
+          println(s"Actual bytes:   ${bytes.map("0x%02X," format _).mkString(" ")}")
+
+          assert(bytes.sameElements(expected), "Written data should match expected EBCDIC encoding")
+        }
+      }
+    }
+  }
+
   def assertArraysEqual(actual: Array[Byte], expected: Array[Byte]): Assertion = {
     if (!actual.sameElements(expected)) {
       val actualHex = actual.map(b => f"0x$b%02X").mkString(", ")


### PR DESCRIPTION
Closes #855 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable floating-point format support for COBOL `COMP-1` and `COMP-2` encoding, including IEEE 754 and IBM variants with selectable endianness (and consistent handling of special values like `NaN`/infinities).

* **Bug Fixes**
  * Ensured the selected floating-point format is correctly applied during primitive encoding.

* **Tests**
  * Added byte-level encoder validation across IEEE 754 and IBM formats, plus writer tests covering multiple `floating_point_format` options with edge-case coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->