### PR TITLE
#862 Exclude custom option namespaces from redundant option validation.

### DIFF
--- a/cobol-parser/src/main/scala/za/co/absa/cobrix/cobol/parser/CopybookParser.scala
+++ b/cobol-parser/src/main/scala/za/co/absa/cobrix/cobol/parser/CopybookParser.scala
@@ -305,7 +305,7 @@ object CopybookParser extends Logging {
     validateFieldParentMap(correctedFieldParentMap)
 
     val transformers = Seq(
-      // Calculate sized of fields and their positions from the beginning of a record
+      // Calculate sizes of fields and their positions from the beginning of a record
       BinaryPropertiesAdder(),
       // Adds virtual primitive fields for GROUPs that can be parsed as concatenation of their children.
       NonTerminalsAdder(nonTerms, enc, stringTrimmingPolicy, ebcdicCodePage, asciiCharset, isUtf16BigEndian, floatingPointFormat, strictSignOverpunch, improvedNullDetection),

--- a/cobol-parser/src/main/scala/za/co/absa/cobrix/cobol/reader/parameters/CobolParametersParser.scala
+++ b/cobol-parser/src/main/scala/za/co/absa/cobrix/cobol/reader/parameters/CobolParametersParser.scala
@@ -946,7 +946,12 @@ object CobolParametersParser extends Logging {
       if (params.isKeyUsed(key)) {
         None
       } else {
-        Some(key)
+        val lowercaseKey = key.toLowerCase
+        if (lowercaseKey.startsWith("custom") || lowercaseKey.startsWith("hidam_") || lowercaseKey.startsWith("db2_") || lowercaseKey.startsWith("_")) {
+          None
+        } else {
+          Some(key)
+        }
       }
     })
 

--- a/spark-cobol/src/test/scala/za/co/absa/cobrix/spark/cobol/CobolSchemaSpec.scala
+++ b/spark-cobol/src/test/scala/za/co/absa/cobrix/spark/cobol/CobolSchemaSpec.scala
@@ -722,6 +722,23 @@ class CobolSchemaSpec extends AnyWordSpec with SimpleComparisonBase {
 
       assert(ex.getMessage == "Redundant or unrecognized option(s) to 'spark-cobol': dummy_option.")
     }
+
+    "do not fail fail on redundant options explicitly used from custom options namespaces" in {
+      val copybook: String =
+        """       01  RECORD.
+          |         05  DATA                PIC X(5).
+          |""".stripMargin
+
+      CobolSchema.fromSparkOptions(Seq(copybook),
+        Map(
+          "pedantic" -> "true",
+          "custom_test" -> "dummy_value",
+          "hidam_test" -> "dummy_value",
+          "db2_test" -> "dummy_value",
+          "_some_test" -> "dummy_value"
+        )
+      )
+    }
   }
 
   "getMaximumSegmentIdLength" should {


### PR DESCRIPTION
Closes #862 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved option validation to accept custom and namespace-prefixed settings without incorrectly flagging them as unrecognized.
  * Prevented pedantic mode from failing when valid custom option keys are provided.

* **Tests**
  * Added regression coverage for custom, HIDAM, DB2, and underscore-prefixed options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->