### PR TITLE
#727 Fix parsing of '88 VALUE1  VALUE +999.9999.' statement that threw 'SytnaxErrorException'.

### DIFF
--- a/cobol-parser/src/main/scala/za/co/absa/cobrix/cobol/parser/antlr/copybookParser.g4
+++ b/cobol-parser/src/main/scala/za/co/absa/cobrix/cobol/parser/antlr/copybookParser.g4
@@ -30,7 +30,7 @@ literal:
     ;
 
 numericLiteral:
-    plusMinus? NUMERICLITERAL | ZERO | plusMinus? integerLiteral
+    plusMinus? NUMERICLITERAL | ZERO | plusMinus? integerLiteral | plusMinus? PRECISION_9_EXPLICIT_DOT
     ;
 
 integerLiteral:

--- a/cobol-parser/src/main/scala/za/co/absa/cobrix/cobol/parser/antlr/copybookParser.java
+++ b/cobol-parser/src/main/scala/za/co/absa/cobrix/cobol/parser/antlr/copybookParser.java
@@ -323,6 +323,7 @@ public class copybookParser extends Parser {
 		public IntegerLiteralContext integerLiteral() {
 			return getRuleContext(IntegerLiteralContext.class,0);
 		}
+		public TerminalNode PRECISION_9_EXPLICIT_DOT() { return getToken(copybookParser.PRECISION_9_EXPLICIT_DOT, 0); }
 		public NumericLiteralContext(ParserRuleContext parent, int invokingState) {
 			super(parent, invokingState);
 		}
@@ -339,9 +340,9 @@ public class copybookParser extends Parser {
 		enterRule(_localctx, 4, RULE_numericLiteral);
 		int _la;
 		try {
-			setState(107);
+			setState(111);
 			_errHandler.sync(this);
-			switch ( getInterpreter().adaptivePredict(_input,5,_ctx) ) {
+			switch ( getInterpreter().adaptivePredict(_input,6,_ctx) ) {
 			case 1:
 				enterOuterAlt(_localctx, 1);
 				{
@@ -383,6 +384,23 @@ public class copybookParser extends Parser {
 				integerLiteral();
 				}
 				break;
+			case 4:
+				enterOuterAlt(_localctx, 4);
+				{
+				setState(108);
+				_errHandler.sync(this);
+				_la = _input.LA(1);
+				if (_la==MINUSCHAR || _la==PLUSCHAR) {
+					{
+					setState(107);
+					plusMinus();
+					}
+				}
+
+				setState(110);
+				match(PRECISION_9_EXPLICIT_DOT);
+				}
+				break;
 			}
 		}
 		catch (RecognitionException re) {
@@ -422,7 +440,7 @@ public class copybookParser extends Parser {
 		try {
 			enterOuterAlt(_localctx, 1);
 			{
-			setState(109);
+			setState(113);
 			_la = _input.LA(1);
 			if ( !(((((_la - 92)) & ~0x3f) == 0 && ((1L << (_la - 92)) & ((1L << (NINES - 92)) | (1L << (LEVEL_ROOT - 92)) | (1L << (LEVEL_REGULAR - 92)) | (1L << (LEVEL_NUMBER_66 - 92)) | (1L << (LEVEL_NUMBER_77 - 92)) | (1L << (LEVEL_NUMBER_88 - 92)) | (1L << (INTEGERLITERAL - 92)))) != 0)) ) {
 			_errHandler.recoverInline(this);
@@ -466,7 +484,7 @@ public class copybookParser extends Parser {
 		try {
 			enterOuterAlt(_localctx, 1);
 			{
-			setState(111);
+			setState(115);
 			_la = _input.LA(1);
 			if ( !(_la==FALSE || _la==TRUE) ) {
 			_errHandler.recoverInline(this);
@@ -586,48 +604,48 @@ public class copybookParser extends Parser {
 		IdentifierContext _localctx = new IdentifierContext(_ctx, getState());
 		enterRule(_localctx, 10, RULE_identifier);
 		try {
-			setState(195);
+			setState(199);
 			_errHandler.sync(this);
-			switch ( getInterpreter().adaptivePredict(_input,6,_ctx) ) {
+			switch ( getInterpreter().adaptivePredict(_input,7,_ctx) ) {
 			case 1:
 				enterOuterAlt(_localctx, 1);
 				{
-				setState(113);
+				setState(117);
 				match(IDENTIFIER);
 				}
 				break;
 			case 2:
 				enterOuterAlt(_localctx, 2);
 				{
-				setState(114);
+				setState(118);
 				match(THRU_OR_THROUGH);
 				}
 				break;
 			case 3:
 				enterOuterAlt(_localctx, 3);
 				{
-				setState(115);
+				setState(119);
 				match(A_S);
 				}
 				break;
 			case 4:
 				enterOuterAlt(_localctx, 4);
 				{
-				setState(116);
+				setState(120);
 				match(P_S);
 				}
 				break;
 			case 5:
 				enterOuterAlt(_localctx, 5);
 				{
-				setState(117);
+				setState(121);
 				match(P_NS);
 				}
 				break;
 			case 6:
 				enterOuterAlt(_localctx, 6);
 				{
-				setState(118);
+				setState(122);
 				match(X_S);
 				}
 				break;
@@ -639,525 +657,525 @@ public class copybookParser extends Parser {
 			case 8:
 				enterOuterAlt(_localctx, 8);
 				{
-				setState(120);
+				setState(124);
 				match(N_S);
 				}
 				break;
 			case 9:
 				enterOuterAlt(_localctx, 9);
 				{
-				setState(121);
+				setState(125);
 				match(S_S);
 				}
 				break;
 			case 10:
 				enterOuterAlt(_localctx, 10);
 				{
-				setState(122);
+				setState(126);
 				match(S_NS);
 				}
 				break;
 			case 11:
 				enterOuterAlt(_localctx, 11);
 				{
-				setState(123);
+				setState(127);
 				match(Z_S);
 				}
 				break;
 			case 12:
 				enterOuterAlt(_localctx, 12);
 				{
-				setState(124);
+				setState(128);
 				match(Z_NS);
 				}
 				break;
 			case 13:
 				enterOuterAlt(_localctx, 13);
 				{
-				setState(125);
+				setState(129);
 				match(V_S);
 				}
 				break;
 			case 14:
 				enterOuterAlt(_localctx, 14);
 				{
-				setState(126);
+				setState(130);
 				match(V_NS);
 				}
 				break;
 			case 15:
 				enterOuterAlt(_localctx, 15);
 				{
-				setState(127);
+				setState(131);
 				match(SINGLE_QUOTED_IDENTIFIER);
 				}
 				break;
 			case 16:
 				enterOuterAlt(_localctx, 16);
 				{
-				setState(128);
+				setState(132);
 				match(SIGN);
 				}
 				break;
 			case 17:
 				enterOuterAlt(_localctx, 17);
 				{
-				setState(129);
+				setState(133);
 				match(LEADING);
 				}
 				break;
 			case 18:
 				enterOuterAlt(_localctx, 18);
 				{
-				setState(130);
+				setState(134);
 				match(TRAILING);
 				}
 				break;
 			case 19:
 				enterOuterAlt(_localctx, 19);
 				{
-				setState(131);
+				setState(135);
 				match(SEPARATE);
 				}
 				break;
 			case 20:
 				enterOuterAlt(_localctx, 20);
 				{
-				setState(132);
+				setState(136);
 				match(CHARACTER);
 				}
 				break;
 			case 21:
 				enterOuterAlt(_localctx, 21);
 				{
-				setState(133);
+				setState(137);
 				match(ASCENDING);
 				}
 				break;
 			case 22:
 				enterOuterAlt(_localctx, 22);
 				{
-				setState(134);
+				setState(138);
 				match(DESCENDING);
 				}
 				break;
 			case 23:
 				enterOuterAlt(_localctx, 23);
 				{
-				setState(135);
+				setState(139);
 				match(KEY);
 				}
 				break;
 			case 24:
 				enterOuterAlt(_localctx, 24);
 				{
-				setState(136);
+				setState(140);
 				match(BINARY);
 				}
 				break;
 			case 25:
 				enterOuterAlt(_localctx, 25);
 				{
-				setState(137);
+				setState(141);
 				match(DISPLAY);
 				}
 				break;
 			case 26:
 				enterOuterAlt(_localctx, 26);
 				{
-				setState(138);
+				setState(142);
 				match(PACKED_DECIMAL);
 				}
 				break;
 			case 27:
 				enterOuterAlt(_localctx, 27);
 				{
-				setState(139);
+				setState(143);
 				match(COMPUTATIONAL);
 				}
 				break;
 			case 28:
 				enterOuterAlt(_localctx, 28);
 				{
-				setState(140);
+				setState(144);
 				match(COMPUTATIONAL_0);
 				}
 				break;
 			case 29:
 				enterOuterAlt(_localctx, 29);
 				{
-				setState(141);
+				setState(145);
 				match(COMPUTATIONAL_1);
 				}
 				break;
 			case 30:
 				enterOuterAlt(_localctx, 30);
 				{
-				setState(142);
+				setState(146);
 				match(COMPUTATIONAL_2);
 				}
 				break;
 			case 31:
 				enterOuterAlt(_localctx, 31);
 				{
-				setState(143);
+				setState(147);
 				match(COMPUTATIONAL_3);
 				}
 				break;
 			case 32:
 				enterOuterAlt(_localctx, 32);
 				{
-				setState(144);
+				setState(148);
 				match(COMPUTATIONAL_3U);
 				}
 				break;
 			case 33:
 				enterOuterAlt(_localctx, 33);
 				{
-				setState(145);
+				setState(149);
 				match(COMPUTATIONAL_4);
 				}
 				break;
 			case 34:
 				enterOuterAlt(_localctx, 34);
 				{
-				setState(146);
+				setState(150);
 				match(COMPUTATIONAL_5);
 				}
 				break;
 			case 35:
 				enterOuterAlt(_localctx, 35);
 				{
-				setState(147);
+				setState(151);
 				match(COMPUTATIONAL_9);
 				}
 				break;
 			case 36:
 				enterOuterAlt(_localctx, 36);
 				{
-				setState(148);
+				setState(152);
 				match(COMP);
 				}
 				break;
 			case 37:
 				enterOuterAlt(_localctx, 37);
 				{
-				setState(149);
+				setState(153);
 				match(COMP_0);
 				}
 				break;
 			case 38:
 				enterOuterAlt(_localctx, 38);
 				{
-				setState(150);
+				setState(154);
 				match(COMP_1);
 				}
 				break;
 			case 39:
 				enterOuterAlt(_localctx, 39);
 				{
-				setState(151);
+				setState(155);
 				match(COMP_2);
 				}
 				break;
 			case 40:
 				enterOuterAlt(_localctx, 40);
 				{
-				setState(152);
+				setState(156);
 				match(COMP_3);
 				}
 				break;
 			case 41:
 				enterOuterAlt(_localctx, 41);
 				{
-				setState(153);
+				setState(157);
 				match(COMP_3U);
 				}
 				break;
 			case 42:
 				enterOuterAlt(_localctx, 42);
 				{
-				setState(154);
+				setState(158);
 				match(COMP_4);
 				}
 				break;
 			case 43:
 				enterOuterAlt(_localctx, 43);
 				{
-				setState(155);
+				setState(159);
 				match(COMP_5);
 				}
 				break;
 			case 44:
 				enterOuterAlt(_localctx, 44);
 				{
-				setState(156);
+				setState(160);
 				match(COMP_9);
 				}
 				break;
 			case 45:
 				enterOuterAlt(_localctx, 45);
 				{
-				setState(157);
+				setState(161);
 				match(REDEFINES);
 				}
 				break;
 			case 46:
 				enterOuterAlt(_localctx, 46);
 				{
-				setState(158);
+				setState(162);
 				match(RENAMES);
 				}
 				break;
 			case 47:
 				enterOuterAlt(_localctx, 47);
 				{
-				setState(159);
+				setState(163);
 				match(VALUE);
 				}
 				break;
 			case 48:
 				enterOuterAlt(_localctx, 48);
 				{
-				setState(160);
+				setState(164);
 				match(VALUES);
 				}
 				break;
 			case 49:
 				enterOuterAlt(_localctx, 49);
 				{
-				setState(161);
+				setState(165);
 				match(OCCURS);
 				}
 				break;
 			case 50:
 				enterOuterAlt(_localctx, 50);
 				{
-				setState(162);
+				setState(166);
 				match(TIMES);
 				}
 				break;
 			case 51:
 				enterOuterAlt(_localctx, 51);
 				{
-				setState(163);
+				setState(167);
 				match(DEPENDING);
 				}
 				break;
 			case 52:
 				enterOuterAlt(_localctx, 52);
 				{
-				setState(164);
+				setState(168);
 				match(INDEXED);
 				}
 				break;
 			case 53:
 				enterOuterAlt(_localctx, 53);
 				{
-				setState(165);
+				setState(169);
 				match(BLANK);
 				}
 				break;
 			case 54:
 				enterOuterAlt(_localctx, 54);
 				{
-				setState(166);
+				setState(170);
 				match(ZERO);
 				}
 				break;
 			case 55:
 				enterOuterAlt(_localctx, 55);
 				{
-				setState(167);
+				setState(171);
 				match(ZEROS);
 				}
 				break;
 			case 56:
 				enterOuterAlt(_localctx, 56);
 				{
-				setState(168);
+				setState(172);
 				match(ZEROES);
 				}
 				break;
 			case 57:
 				enterOuterAlt(_localctx, 57);
 				{
-				setState(169);
+				setState(173);
 				match(SPACE);
 				}
 				break;
 			case 58:
 				enterOuterAlt(_localctx, 58);
 				{
-				setState(170);
+				setState(174);
 				match(SPACES);
 				}
 				break;
 			case 59:
 				enterOuterAlt(_localctx, 59);
 				{
-				setState(171);
+				setState(175);
 				match(HIGH_VALUE);
 				}
 				break;
 			case 60:
 				enterOuterAlt(_localctx, 60);
 				{
-				setState(172);
+				setState(176);
 				match(HIGH_VALUES);
 				}
 				break;
 			case 61:
 				enterOuterAlt(_localctx, 61);
 				{
-				setState(173);
+				setState(177);
 				match(LOW_VALUE);
 				}
 				break;
 			case 62:
 				enterOuterAlt(_localctx, 62);
 				{
-				setState(174);
+				setState(178);
 				match(LOW_VALUES);
 				}
 				break;
 			case 63:
 				enterOuterAlt(_localctx, 63);
 				{
-				setState(175);
+				setState(179);
 				match(NULL);
 				}
 				break;
 			case 64:
 				enterOuterAlt(_localctx, 64);
 				{
-				setState(176);
+				setState(180);
 				match(NULLS);
 				}
 				break;
 			case 65:
 				enterOuterAlt(_localctx, 65);
 				{
-				setState(177);
+				setState(181);
 				match(QUOTE);
 				}
 				break;
 			case 66:
 				enterOuterAlt(_localctx, 66);
 				{
-				setState(178);
+				setState(182);
 				match(QUOTES);
 				}
 				break;
 			case 67:
 				enterOuterAlt(_localctx, 67);
 				{
-				setState(179);
+				setState(183);
 				match(JUSTIFIED);
 				}
 				break;
 			case 68:
 				enterOuterAlt(_localctx, 68);
 				{
-				setState(180);
+				setState(184);
 				match(JUST);
 				}
 				break;
 			case 69:
 				enterOuterAlt(_localctx, 69);
 				{
-				setState(181);
+				setState(185);
 				match(RIGHT);
 				}
 				break;
 			case 70:
 				enterOuterAlt(_localctx, 70);
 				{
-				setState(182);
+				setState(186);
 				match(PICTURE);
 				}
 				break;
 			case 71:
 				enterOuterAlt(_localctx, 71);
 				{
-				setState(183);
+				setState(187);
 				match(PIC);
 				}
 				break;
 			case 72:
 				enterOuterAlt(_localctx, 72);
 				{
-				setState(184);
+				setState(188);
 				match(TRUE);
 				}
 				break;
 			case 73:
 				enterOuterAlt(_localctx, 73);
 				{
-				setState(185);
+				setState(189);
 				match(FALSE);
 				}
 				break;
 			case 74:
 				enterOuterAlt(_localctx, 74);
 				{
-				setState(186);
+				setState(190);
 				match(ARE);
 				}
 				break;
 			case 75:
 				enterOuterAlt(_localctx, 75);
 				{
-				setState(187);
+				setState(191);
 				match(IS);
 				}
 				break;
 			case 76:
 				enterOuterAlt(_localctx, 76);
 				{
-				setState(188);
+				setState(192);
 				match(ON);
 				}
 				break;
 			case 77:
 				enterOuterAlt(_localctx, 77);
 				{
-				setState(189);
+				setState(193);
 				match(BY);
 				}
 				break;
 			case 78:
 				enterOuterAlt(_localctx, 78);
 				{
-				setState(190);
+				setState(194);
 				match(WHEN);
 				}
 				break;
 			case 79:
 				enterOuterAlt(_localctx, 79);
 				{
-				setState(191);
+				setState(195);
 				match(TO);
 				}
 				break;
 			case 80:
 				enterOuterAlt(_localctx, 80);
 				{
-				setState(192);
+				setState(196);
 				match(ALL);
 				}
 				break;
 			case 81:
 				enterOuterAlt(_localctx, 81);
 				{
-				setState(193);
+				setState(197);
 				match(USAGE);
 				}
 				break;
 			case 82:
 				enterOuterAlt(_localctx, 82);
 				{
-				setState(194);
+				setState(198);
 				match(FROM);
 				}
 				break;
@@ -1193,7 +1211,7 @@ public class copybookParser extends Parser {
 		try {
 			enterOuterAlt(_localctx, 1);
 			{
-			setState(197);
+			setState(201);
 			match(THRU_OR_THROUGH);
 			}
 		}
@@ -1241,19 +1259,19 @@ public class copybookParser extends Parser {
 		try {
 			enterOuterAlt(_localctx, 1);
 			{
-			setState(207);
+			setState(211);
 			_errHandler.sync(this);
 			switch (_input.LA(1)) {
 			case VALUE:
 				{
-				setState(199);
+				setState(203);
 				match(VALUE);
-				setState(201);
+				setState(205);
 				_errHandler.sync(this);
 				_la = _input.LA(1);
 				if (_la==IS) {
 					{
-					setState(200);
+					setState(204);
 					match(IS);
 					}
 				}
@@ -1262,14 +1280,14 @@ public class copybookParser extends Parser {
 				break;
 			case VALUES:
 				{
-				setState(203);
+				setState(207);
 				match(VALUES);
-				setState(205);
+				setState(209);
 				_errHandler.sync(this);
 				_la = _input.LA(1);
 				if (_la==ARE) {
 					{
-					setState(204);
+					setState(208);
 					match(ARE);
 					}
 				}
@@ -1279,29 +1297,29 @@ public class copybookParser extends Parser {
 			default:
 				throw new NoViableAltException(this);
 			}
-			setState(209);
+			setState(213);
 			valuesFromTo();
-			setState(216);
+			setState(220);
 			_errHandler.sync(this);
 			_la = _input.LA(1);
-			while ((((_la) & ~0x3f) == 0 && ((1L << _la) & ((1L << ALL) | (1L << FALSE) | (1L << HIGH_VALUE) | (1L << HIGH_VALUES) | (1L << LOW_VALUE) | (1L << LOW_VALUES) | (1L << NULL) | (1L << NULLS) | (1L << QUOTE) | (1L << QUOTES))) != 0) || ((((_la - 65)) & ~0x3f) == 0 && ((1L << (_la - 65)) & ((1L << (SPACE - 65)) | (1L << (SPACES - 65)) | (1L << (TRUE - 65)) | (1L << (ZERO - 65)) | (1L << (ZEROS - 65)) | (1L << (ZEROES - 65)) | (1L << (COMMACHAR - 65)) | (1L << (MINUSCHAR - 65)) | (1L << (PLUSCHAR - 65)) | (1L << (NINES - 65)) | (1L << (STRINGLITERAL - 65)) | (1L << (LEVEL_ROOT - 65)) | (1L << (LEVEL_REGULAR - 65)) | (1L << (LEVEL_NUMBER_66 - 65)) | (1L << (LEVEL_NUMBER_77 - 65)))) != 0) || ((((_la - 129)) & ~0x3f) == 0 && ((1L << (_la - 129)) & ((1L << (LEVEL_NUMBER_88 - 129)) | (1L << (INTEGERLITERAL - 129)) | (1L << (NUMERICLITERAL - 129)))) != 0)) {
+			while ((((_la) & ~0x3f) == 0 && ((1L << _la) & ((1L << ALL) | (1L << FALSE) | (1L << HIGH_VALUE) | (1L << HIGH_VALUES) | (1L << LOW_VALUE) | (1L << LOW_VALUES) | (1L << NULL) | (1L << NULLS) | (1L << QUOTE) | (1L << QUOTES))) != 0) || ((((_la - 65)) & ~0x3f) == 0 && ((1L << (_la - 65)) & ((1L << (SPACE - 65)) | (1L << (SPACES - 65)) | (1L << (TRUE - 65)) | (1L << (ZERO - 65)) | (1L << (ZEROS - 65)) | (1L << (ZEROES - 65)) | (1L << (COMMACHAR - 65)) | (1L << (MINUSCHAR - 65)) | (1L << (PLUSCHAR - 65)) | (1L << (NINES - 65)) | (1L << (PRECISION_9_EXPLICIT_DOT - 65)) | (1L << (STRINGLITERAL - 65)) | (1L << (LEVEL_ROOT - 65)) | (1L << (LEVEL_REGULAR - 65)) | (1L << (LEVEL_NUMBER_66 - 65)) | (1L << (LEVEL_NUMBER_77 - 65)))) != 0) || ((((_la - 129)) & ~0x3f) == 0 && ((1L << (_la - 129)) & ((1L << (LEVEL_NUMBER_88 - 129)) | (1L << (INTEGERLITERAL - 129)) | (1L << (NUMERICLITERAL - 129)))) != 0)) {
 				{
 				{
-				setState(211);
+				setState(215);
 				_errHandler.sync(this);
 				_la = _input.LA(1);
 				if (_la==COMMACHAR) {
 					{
-					setState(210);
+					setState(214);
 					match(COMMACHAR);
 					}
 				}
 
-				setState(213);
+				setState(217);
 				valuesFromTo();
 				}
 				}
-				setState(218);
+				setState(222);
 				_errHandler.sync(this);
 				_la = _input.LA(1);
 			}
@@ -1343,14 +1361,14 @@ public class copybookParser extends Parser {
 		try {
 			enterOuterAlt(_localctx, 1);
 			{
-			setState(219);
+			setState(223);
 			valuesFrom();
-			setState(221);
+			setState(225);
 			_errHandler.sync(this);
 			_la = _input.LA(1);
 			if (_la==THRU_OR_THROUGH) {
 				{
-				setState(220);
+				setState(224);
 				valuesTo();
 				}
 			}
@@ -1389,7 +1407,7 @@ public class copybookParser extends Parser {
 		try {
 			enterOuterAlt(_localctx, 1);
 			{
-			setState(223);
+			setState(227);
 			literal();
 			}
 		}
@@ -1428,9 +1446,9 @@ public class copybookParser extends Parser {
 		try {
 			enterOuterAlt(_localctx, 1);
 			{
-			setState(225);
+			setState(229);
 			thru();
-			setState(226);
+			setState(230);
 			literal();
 			}
 		}
@@ -1478,106 +1496,106 @@ public class copybookParser extends Parser {
 		SpecialValuesContext _localctx = new SpecialValuesContext(_ctx, getState());
 		enterRule(_localctx, 22, RULE_specialValues);
 		try {
-			setState(243);
+			setState(247);
 			_errHandler.sync(this);
 			switch (_input.LA(1)) {
 			case ALL:
 				enterOuterAlt(_localctx, 1);
 				{
-				setState(228);
+				setState(232);
 				match(ALL);
-				setState(229);
+				setState(233);
 				literal();
 				}
 				break;
 			case HIGH_VALUE:
 				enterOuterAlt(_localctx, 2);
 				{
-				setState(230);
+				setState(234);
 				match(HIGH_VALUE);
 				}
 				break;
 			case HIGH_VALUES:
 				enterOuterAlt(_localctx, 3);
 				{
-				setState(231);
+				setState(235);
 				match(HIGH_VALUES);
 				}
 				break;
 			case LOW_VALUE:
 				enterOuterAlt(_localctx, 4);
 				{
-				setState(232);
+				setState(236);
 				match(LOW_VALUE);
 				}
 				break;
 			case LOW_VALUES:
 				enterOuterAlt(_localctx, 5);
 				{
-				setState(233);
+				setState(237);
 				match(LOW_VALUES);
 				}
 				break;
 			case NULL:
 				enterOuterAlt(_localctx, 6);
 				{
-				setState(234);
+				setState(238);
 				match(NULL);
 				}
 				break;
 			case NULLS:
 				enterOuterAlt(_localctx, 7);
 				{
-				setState(235);
+				setState(239);
 				match(NULLS);
 				}
 				break;
 			case QUOTE:
 				enterOuterAlt(_localctx, 8);
 				{
-				setState(236);
+				setState(240);
 				match(QUOTE);
 				}
 				break;
 			case QUOTES:
 				enterOuterAlt(_localctx, 9);
 				{
-				setState(237);
+				setState(241);
 				match(QUOTES);
 				}
 				break;
 			case SPACE:
 				enterOuterAlt(_localctx, 10);
 				{
-				setState(238);
+				setState(242);
 				match(SPACE);
 				}
 				break;
 			case SPACES:
 				enterOuterAlt(_localctx, 11);
 				{
-				setState(239);
+				setState(243);
 				match(SPACES);
 				}
 				break;
 			case ZERO:
 				enterOuterAlt(_localctx, 12);
 				{
-				setState(240);
+				setState(244);
 				match(ZERO);
 				}
 				break;
 			case ZEROS:
 				enterOuterAlt(_localctx, 13);
 				{
-				setState(241);
+				setState(245);
 				match(ZEROS);
 				}
 				break;
 			case ZEROES:
 				enterOuterAlt(_localctx, 14);
 				{
-				setState(242);
+				setState(246);
 				match(ZEROES);
 				}
 				break;
@@ -1622,7 +1640,7 @@ public class copybookParser extends Parser {
 		try {
 			enterOuterAlt(_localctx, 1);
 			{
-			setState(245);
+			setState(249);
 			_la = _input.LA(1);
 			if ( !(_la==ASCENDING || _la==DESCENDING) ) {
 			_errHandler.recoverInline(this);
@@ -1632,27 +1650,27 @@ public class copybookParser extends Parser {
 				_errHandler.reportMatch(this);
 				consume();
 			}
-			setState(247);
-			_errHandler.sync(this);
-			switch ( getInterpreter().adaptivePredict(_input,14,_ctx) ) {
-			case 1:
-				{
-				setState(246);
-				match(KEY);
-				}
-				break;
-			}
-			setState(250);
+			setState(251);
 			_errHandler.sync(this);
 			switch ( getInterpreter().adaptivePredict(_input,15,_ctx) ) {
 			case 1:
 				{
-				setState(249);
+				setState(250);
+				match(KEY);
+				}
+				break;
+			}
+			setState(254);
+			_errHandler.sync(this);
+			switch ( getInterpreter().adaptivePredict(_input,16,_ctx) ) {
+			case 1:
+				{
+				setState(253);
 				match(IS);
 				}
 				break;
 			}
-			setState(252);
+			setState(256);
 			identifier();
 			}
 		}
@@ -1689,9 +1707,9 @@ public class copybookParser extends Parser {
 		try {
 			enterOuterAlt(_localctx, 1);
 			{
-			setState(254);
+			setState(258);
 			match(TO);
-			setState(255);
+			setState(259);
 			integerLiteral();
 			}
 		}
@@ -1729,19 +1747,19 @@ public class copybookParser extends Parser {
 		try {
 			enterOuterAlt(_localctx, 1);
 			{
-			setState(257);
+			setState(261);
 			match(DEPENDING);
-			setState(259);
+			setState(263);
 			_errHandler.sync(this);
-			switch ( getInterpreter().adaptivePredict(_input,16,_ctx) ) {
+			switch ( getInterpreter().adaptivePredict(_input,17,_ctx) ) {
 			case 1:
 				{
-				setState(258);
+				setState(262);
 				match(ON);
 				}
 				break;
 			}
-			setState(261);
+			setState(265);
 			identifier();
 			}
 		}
@@ -1788,41 +1806,41 @@ public class copybookParser extends Parser {
 		try {
 			enterOuterAlt(_localctx, 1);
 			{
-			setState(263);
+			setState(267);
 			match(INDEXED);
-			setState(265);
+			setState(269);
 			_errHandler.sync(this);
-			switch ( getInterpreter().adaptivePredict(_input,17,_ctx) ) {
+			switch ( getInterpreter().adaptivePredict(_input,18,_ctx) ) {
 			case 1:
 				{
-				setState(264);
+				setState(268);
 				match(BY);
 				}
 				break;
 			}
-			setState(267);
+			setState(271);
 			identifier();
-			setState(274);
+			setState(278);
 			_errHandler.sync(this);
 			_la = _input.LA(1);
 			while (_la==COMMACHAR || _la==IDENTIFIER) {
 				{
 				{
-				setState(269);
+				setState(273);
 				_errHandler.sync(this);
 				_la = _input.LA(1);
 				if (_la==COMMACHAR) {
 					{
-					setState(268);
+					setState(272);
 					match(COMMACHAR);
 					}
 				}
 
-				setState(271);
+				setState(275);
 				match(IDENTIFIER);
 				}
 				}
-				setState(276);
+				setState(280);
 				_errHandler.sync(this);
 				_la = _input.LA(1);
 			}
@@ -1875,56 +1893,56 @@ public class copybookParser extends Parser {
 		try {
 			enterOuterAlt(_localctx, 1);
 			{
-			setState(277);
+			setState(281);
 			match(OCCURS);
-			setState(278);
+			setState(282);
 			integerLiteral();
-			setState(280);
+			setState(284);
 			_errHandler.sync(this);
 			_la = _input.LA(1);
 			if (_la==TO) {
 				{
-				setState(279);
+				setState(283);
 				occursTo();
 				}
 			}
 
-			setState(283);
+			setState(287);
 			_errHandler.sync(this);
 			_la = _input.LA(1);
 			if (_la==TIMES) {
 				{
-				setState(282);
+				setState(286);
 				match(TIMES);
 				}
 			}
 
-			setState(286);
+			setState(290);
 			_errHandler.sync(this);
 			_la = _input.LA(1);
 			if (_la==DEPENDING) {
 				{
-				setState(285);
+				setState(289);
 				dependingOn();
 				}
 			}
 
-			setState(289);
+			setState(293);
 			_errHandler.sync(this);
 			_la = _input.LA(1);
 			if (_la==ASCENDING || _la==DESCENDING) {
 				{
-				setState(288);
+				setState(292);
 				sorts();
 				}
 			}
 
-			setState(292);
+			setState(296);
 			_errHandler.sync(this);
 			_la = _input.LA(1);
 			if (_la==INDEXED) {
 				{
-				setState(291);
+				setState(295);
 				indexedBy();
 				}
 			}
@@ -1964,9 +1982,9 @@ public class copybookParser extends Parser {
 		try {
 			enterOuterAlt(_localctx, 1);
 			{
-			setState(294);
+			setState(298);
 			match(REDEFINES);
-			setState(295);
+			setState(299);
 			identifier();
 			}
 		}
@@ -2010,18 +2028,18 @@ public class copybookParser extends Parser {
 		try {
 			enterOuterAlt(_localctx, 1);
 			{
-			setState(297);
+			setState(301);
 			match(RENAMES);
-			setState(298);
-			identifier();
 			setState(302);
+			identifier();
+			setState(306);
 			_errHandler.sync(this);
 			_la = _input.LA(1);
 			if (_la==THRU_OR_THROUGH) {
 				{
-				setState(299);
+				setState(303);
 				thru();
-				setState(300);
+				setState(304);
 				identifier();
 				}
 			}
@@ -2079,7 +2097,7 @@ public class copybookParser extends Parser {
 		try {
 			enterOuterAlt(_localctx, 1);
 			{
-			setState(304);
+			setState(308);
 			_la = _input.LA(1);
 			if ( !((((_la) & ~0x3f) == 0 && ((1L << _la) & ((1L << BINARY) | (1L << COMP) | (1L << COMP_0) | (1L << COMP_1) | (1L << COMP_2) | (1L << COMP_3) | (1L << COMP_3U) | (1L << COMP_4) | (1L << COMP_5) | (1L << COMP_9) | (1L << COMPUTATIONAL) | (1L << COMPUTATIONAL_0) | (1L << COMPUTATIONAL_1) | (1L << COMPUTATIONAL_2) | (1L << COMPUTATIONAL_3) | (1L << COMPUTATIONAL_3U) | (1L << COMPUTATIONAL_4) | (1L << COMPUTATIONAL_5) | (1L << COMPUTATIONAL_9) | (1L << DISPLAY) | (1L << PACKED_DECIMAL))) != 0)) ) {
 			_errHandler.recoverInline(this);
@@ -2138,7 +2156,7 @@ public class copybookParser extends Parser {
 		try {
 			enterOuterAlt(_localctx, 1);
 			{
-			setState(306);
+			setState(310);
 			_la = _input.LA(1);
 			if ( !((((_la) & ~0x3f) == 0 && ((1L << _la) & ((1L << BINARY) | (1L << COMP) | (1L << COMP_0) | (1L << COMP_3) | (1L << COMP_3U) | (1L << COMP_4) | (1L << COMP_5) | (1L << COMP_9) | (1L << COMPUTATIONAL) | (1L << COMPUTATIONAL_0) | (1L << COMPUTATIONAL_3) | (1L << COMPUTATIONAL_3U) | (1L << COMPUTATIONAL_4) | (1L << COMPUTATIONAL_5) | (1L << COMPUTATIONAL_9) | (1L << DISPLAY) | (1L << PACKED_DECIMAL))) != 0)) ) {
 			_errHandler.recoverInline(this);
@@ -2185,19 +2203,19 @@ public class copybookParser extends Parser {
 		try {
 			enterOuterAlt(_localctx, 1);
 			{
-			setState(312);
+			setState(316);
 			_errHandler.sync(this);
 			_la = _input.LA(1);
 			if (_la==USAGE) {
 				{
-				setState(308);
+				setState(312);
 				match(USAGE);
-				setState(310);
+				setState(314);
 				_errHandler.sync(this);
 				_la = _input.LA(1);
 				if (_la==IS) {
 					{
-					setState(309);
+					setState(313);
 					match(IS);
 					}
 				}
@@ -2205,7 +2223,7 @@ public class copybookParser extends Parser {
 				}
 			}
 
-			setState(314);
+			setState(318);
 			usageLiteral();
 			}
 		}
@@ -2244,19 +2262,19 @@ public class copybookParser extends Parser {
 		try {
 			enterOuterAlt(_localctx, 1);
 			{
-			setState(320);
+			setState(324);
 			_errHandler.sync(this);
 			_la = _input.LA(1);
 			if (_la==USAGE) {
 				{
-				setState(316);
+				setState(320);
 				match(USAGE);
-				setState(318);
+				setState(322);
 				_errHandler.sync(this);
 				_la = _input.LA(1);
 				if (_la==IS) {
 					{
-					setState(317);
+					setState(321);
 					match(IS);
 					}
 				}
@@ -2264,7 +2282,7 @@ public class copybookParser extends Parser {
 				}
 			}
 
-			setState(322);
+			setState(326);
 			groupUsageLiteral();
 			}
 		}
@@ -2304,19 +2322,19 @@ public class copybookParser extends Parser {
 		try {
 			enterOuterAlt(_localctx, 1);
 			{
-			setState(324);
+			setState(328);
 			match(SIGN);
-			setState(326);
+			setState(330);
 			_errHandler.sync(this);
 			_la = _input.LA(1);
 			if (_la==IS) {
 				{
-				setState(325);
+				setState(329);
 				match(IS);
 				}
 			}
 
-			setState(328);
+			setState(332);
 			_la = _input.LA(1);
 			if ( !(_la==LEADING || _la==TRAILING) ) {
 			_errHandler.recoverInline(this);
@@ -2326,22 +2344,22 @@ public class copybookParser extends Parser {
 				_errHandler.reportMatch(this);
 				consume();
 			}
-			setState(330);
+			setState(334);
 			_errHandler.sync(this);
 			_la = _input.LA(1);
 			if (_la==SEPARATE) {
 				{
-				setState(329);
+				setState(333);
 				match(SEPARATE);
 				}
 			}
 
-			setState(333);
+			setState(337);
 			_errHandler.sync(this);
 			_la = _input.LA(1);
 			if (_la==CHARACTER) {
 				{
-				setState(332);
+				setState(336);
 				match(CHARACTER);
 				}
 			}
@@ -2381,7 +2399,7 @@ public class copybookParser extends Parser {
 		try {
 			enterOuterAlt(_localctx, 1);
 			{
-			setState(335);
+			setState(339);
 			_la = _input.LA(1);
 			if ( !(_la==JUST || _la==JUSTIFIED) ) {
 			_errHandler.recoverInline(this);
@@ -2391,12 +2409,12 @@ public class copybookParser extends Parser {
 				_errHandler.reportMatch(this);
 				consume();
 			}
-			setState(337);
+			setState(341);
 			_errHandler.sync(this);
 			_la = _input.LA(1);
 			if (_la==RIGHT) {
 				{
-				setState(336);
+				setState(340);
 				match(RIGHT);
 				}
 			}
@@ -2433,7 +2451,7 @@ public class copybookParser extends Parser {
 		try {
 			enterOuterAlt(_localctx, 1);
 			{
-			setState(339);
+			setState(343);
 			match(TERMINAL);
 			}
 		}
@@ -2482,14 +2500,14 @@ public class copybookParser extends Parser {
 		PlusMinusContext _localctx = new PlusMinusContext(_ctx, getState());
 		enterRule(_localctx, 52, RULE_plusMinus);
 		try {
-			setState(343);
+			setState(347);
 			_errHandler.sync(this);
 			switch (_input.LA(1)) {
 			case PLUSCHAR:
 				_localctx = new PlusContext(_localctx);
 				enterOuterAlt(_localctx, 1);
 				{
-				setState(341);
+				setState(345);
 				match(PLUSCHAR);
 				}
 				break;
@@ -2497,7 +2515,7 @@ public class copybookParser extends Parser {
 				_localctx = new MinusContext(_localctx);
 				enterOuterAlt(_localctx, 2);
 				{
-				setState(342);
+				setState(346);
 				match(MINUSCHAR);
 				}
 				break;
@@ -2649,14 +2667,14 @@ public class copybookParser extends Parser {
 		Precision9Context _localctx = new Precision9Context(_ctx, getState());
 		enterRule(_localctx, 54, RULE_precision9);
 		try {
-			setState(358);
+			setState(362);
 			_errHandler.sync(this);
 			switch (_input.LA(1)) {
 			case NINES:
 				_localctx = new Precision9NinesContext(_localctx);
 				enterOuterAlt(_localctx, 1);
 				{
-				setState(345);
+				setState(349);
 				match(NINES);
 				}
 				break;
@@ -2664,7 +2682,7 @@ public class copybookParser extends Parser {
 				_localctx = new Precision9SsContext(_localctx);
 				enterOuterAlt(_localctx, 2);
 				{
-				setState(346);
+				setState(350);
 				match(S_S);
 				}
 				break;
@@ -2672,7 +2690,7 @@ public class copybookParser extends Parser {
 				_localctx = new Precision9PsContext(_localctx);
 				enterOuterAlt(_localctx, 3);
 				{
-				setState(347);
+				setState(351);
 				match(P_S);
 				}
 				break;
@@ -2680,7 +2698,7 @@ public class copybookParser extends Parser {
 				_localctx = new Precision9ZsContext(_localctx);
 				enterOuterAlt(_localctx, 4);
 				{
-				setState(348);
+				setState(352);
 				match(Z_S);
 				}
 				break;
@@ -2688,7 +2706,7 @@ public class copybookParser extends Parser {
 				_localctx = new Precision9VsContext(_localctx);
 				enterOuterAlt(_localctx, 5);
 				{
-				setState(349);
+				setState(353);
 				match(V_S);
 				}
 				break;
@@ -2696,7 +2714,7 @@ public class copybookParser extends Parser {
 				_localctx = new Precision9ExplicitDotContext(_localctx);
 				enterOuterAlt(_localctx, 6);
 				{
-				setState(350);
+				setState(354);
 				match(PRECISION_9_EXPLICIT_DOT);
 				}
 				break;
@@ -2704,7 +2722,7 @@ public class copybookParser extends Parser {
 				_localctx = new Precision9DecimalScaledContext(_localctx);
 				enterOuterAlt(_localctx, 7);
 				{
-				setState(351);
+				setState(355);
 				match(PRECISION_9_DECIMAL_SCALED);
 				}
 				break;
@@ -2712,7 +2730,7 @@ public class copybookParser extends Parser {
 				_localctx = new Precision9DecimalScaledWithVContext(_localctx);
 				enterOuterAlt(_localctx, 8);
 				{
-				setState(352);
+				setState(356);
 				match(PRECISION_9_DECIMAL_WITH_V);
 				}
 				break;
@@ -2720,7 +2738,7 @@ public class copybookParser extends Parser {
 				_localctx = new Precision9ScaledContext(_localctx);
 				enterOuterAlt(_localctx, 9);
 				{
-				setState(353);
+				setState(357);
 				match(PRECISION_9_SCALED);
 				}
 				break;
@@ -2728,7 +2746,7 @@ public class copybookParser extends Parser {
 				_localctx = new Precision9ScaledLeadContext(_localctx);
 				enterOuterAlt(_localctx, 10);
 				{
-				setState(354);
+				setState(358);
 				match(PRECISION_9_SCALED_LEAD);
 				}
 				break;
@@ -2736,7 +2754,7 @@ public class copybookParser extends Parser {
 				_localctx = new PrecisionZExplicitDotContext(_localctx);
 				enterOuterAlt(_localctx, 11);
 				{
-				setState(355);
+				setState(359);
 				match(PRECISION_Z_EXPLICIT_DOT);
 				}
 				break;
@@ -2744,7 +2762,7 @@ public class copybookParser extends Parser {
 				_localctx = new PrecisionZDecimalScaledContext(_localctx);
 				enterOuterAlt(_localctx, 12);
 				{
-				setState(356);
+				setState(360);
 				match(PRECISION_Z_DECIMAL_SCALED);
 				}
 				break;
@@ -2752,7 +2770,7 @@ public class copybookParser extends Parser {
 				_localctx = new PrecisionZScaledContext(_localctx);
 				enterOuterAlt(_localctx, 13);
 				{
-				setState(357);
+				setState(361);
 				match(PRECISION_Z_SCALED);
 				}
 				break;
@@ -2816,25 +2834,25 @@ public class copybookParser extends Parser {
 		enterRule(_localctx, 56, RULE_signPrecision9);
 		int _la;
 		try {
-			setState(367);
+			setState(371);
 			_errHandler.sync(this);
-			switch ( getInterpreter().adaptivePredict(_input,37,_ctx) ) {
+			switch ( getInterpreter().adaptivePredict(_input,38,_ctx) ) {
 			case 1:
 				_localctx = new LeadingSignContext(_localctx);
 				enterOuterAlt(_localctx, 1);
 				{
 				{
-				setState(361);
+				setState(365);
 				_errHandler.sync(this);
 				_la = _input.LA(1);
 				if (_la==MINUSCHAR || _la==PLUSCHAR) {
 					{
-					setState(360);
+					setState(364);
 					plusMinus();
 					}
 				}
 
-				setState(363);
+				setState(367);
 				precision9();
 				}
 				}
@@ -2844,9 +2862,9 @@ public class copybookParser extends Parser {
 				enterOuterAlt(_localctx, 2);
 				{
 				{
-				setState(364);
+				setState(368);
 				precision9();
-				setState(365);
+				setState(369);
 				plusMinus();
 				}
 				}
@@ -2885,7 +2903,7 @@ public class copybookParser extends Parser {
 		try {
 			enterOuterAlt(_localctx, 1);
 			{
-			setState(369);
+			setState(373);
 			_la = _input.LA(1);
 			if ( !(_la==X_S || _la==LENGTH_TYPE_X) ) {
 			_errHandler.recoverInline(this);
@@ -2929,7 +2947,7 @@ public class copybookParser extends Parser {
 		try {
 			enterOuterAlt(_localctx, 1);
 			{
-			setState(371);
+			setState(375);
 			_la = _input.LA(1);
 			if ( !(_la==N_S || _la==LENGTH_TYPE_N) ) {
 			_errHandler.recoverInline(this);
@@ -2973,7 +2991,7 @@ public class copybookParser extends Parser {
 		try {
 			enterOuterAlt(_localctx, 1);
 			{
-			setState(373);
+			setState(377);
 			_la = _input.LA(1);
 			if ( !(_la==A_S || _la==LENGTH_TYPE_A) ) {
 			_errHandler.recoverInline(this);
@@ -3017,7 +3035,7 @@ public class copybookParser extends Parser {
 		try {
 			enterOuterAlt(_localctx, 1);
 			{
-			setState(375);
+			setState(379);
 			_la = _input.LA(1);
 			if ( !(_la==PIC || _la==PICTURE) ) {
 			_errHandler.recoverInline(this);
@@ -3079,35 +3097,35 @@ public class copybookParser extends Parser {
 		enterRule(_localctx, 66, RULE_pic);
 		int _la;
 		try {
-			setState(407);
+			setState(411);
 			_errHandler.sync(this);
-			switch ( getInterpreter().adaptivePredict(_input,46,_ctx) ) {
+			switch ( getInterpreter().adaptivePredict(_input,47,_ctx) ) {
 			case 1:
 				enterOuterAlt(_localctx, 1);
 				{
-				setState(377);
+				setState(381);
 				pictureLiteral();
-				setState(391);
+				setState(395);
 				_errHandler.sync(this);
 				switch (_input.LA(1)) {
 				case X_S:
 				case LENGTH_TYPE_X:
 					{
-					setState(378);
+					setState(382);
 					alphaX();
 					}
 					break;
 				case A_S:
 				case LENGTH_TYPE_A:
 					{
-					setState(379);
+					setState(383);
 					alphaA();
 					}
 					break;
 				case N_S:
 				case LENGTH_TYPE_N:
 					{
-					setState(380);
+					setState(384);
 					alphaN();
 					}
 					break;
@@ -3149,19 +3167,19 @@ public class copybookParser extends Parser {
 				case PRECISION_Z_DECIMAL_SCALED:
 				case PRECISION_Z_SCALED:
 					{
-					setState(389);
+					setState(393);
 					_errHandler.sync(this);
-					switch ( getInterpreter().adaptivePredict(_input,40,_ctx) ) {
+					switch ( getInterpreter().adaptivePredict(_input,41,_ctx) ) {
 					case 1:
 						{
-						setState(381);
+						setState(385);
 						signPrecision9();
-						setState(383);
+						setState(387);
 						_errHandler.sync(this);
-						switch ( getInterpreter().adaptivePredict(_input,38,_ctx) ) {
+						switch ( getInterpreter().adaptivePredict(_input,39,_ctx) ) {
 						case 1:
 							{
-							setState(382);
+							setState(386);
 							usage();
 							}
 							break;
@@ -3170,17 +3188,17 @@ public class copybookParser extends Parser {
 						break;
 					case 2:
 						{
-						setState(386);
+						setState(390);
 						_errHandler.sync(this);
 						_la = _input.LA(1);
 						if ((((_la) & ~0x3f) == 0 && ((1L << _la) & ((1L << BINARY) | (1L << COMP) | (1L << COMP_0) | (1L << COMP_1) | (1L << COMP_2) | (1L << COMP_3) | (1L << COMP_3U) | (1L << COMP_4) | (1L << COMP_5) | (1L << COMP_9) | (1L << COMPUTATIONAL) | (1L << COMPUTATIONAL_0) | (1L << COMPUTATIONAL_1) | (1L << COMPUTATIONAL_2) | (1L << COMPUTATIONAL_3) | (1L << COMPUTATIONAL_3U) | (1L << COMPUTATIONAL_4) | (1L << COMPUTATIONAL_5) | (1L << COMPUTATIONAL_9) | (1L << DISPLAY) | (1L << PACKED_DECIMAL))) != 0) || _la==USAGE) {
 							{
-							setState(385);
+							setState(389);
 							usage();
 							}
 						}
 
-						setState(388);
+						setState(392);
 						signPrecision9();
 						}
 						break;
@@ -3195,19 +3213,19 @@ public class copybookParser extends Parser {
 			case 2:
 				enterOuterAlt(_localctx, 2);
 				{
-				setState(397);
+				setState(401);
 				_errHandler.sync(this);
 				_la = _input.LA(1);
 				if (_la==USAGE) {
 					{
-					setState(393);
+					setState(397);
 					match(USAGE);
-					setState(395);
+					setState(399);
 					_errHandler.sync(this);
 					_la = _input.LA(1);
 					if (_la==IS) {
 						{
-						setState(394);
+						setState(398);
 						match(IS);
 						}
 					}
@@ -3215,26 +3233,26 @@ public class copybookParser extends Parser {
 					}
 				}
 
-				setState(399);
+				setState(403);
 				match(COMP_1);
 				}
 				break;
 			case 3:
 				enterOuterAlt(_localctx, 3);
 				{
-				setState(404);
+				setState(408);
 				_errHandler.sync(this);
 				_la = _input.LA(1);
 				if (_la==USAGE) {
 					{
-					setState(400);
+					setState(404);
 					match(USAGE);
-					setState(402);
+					setState(406);
 					_errHandler.sync(this);
 					_la = _input.LA(1);
 					if (_la==IS) {
 						{
-						setState(401);
+						setState(405);
 						match(IS);
 						}
 					}
@@ -3242,7 +3260,7 @@ public class copybookParser extends Parser {
 					}
 				}
 
-				setState(406);
+				setState(410);
 				match(COMP_2);
 				}
 				break;
@@ -3280,7 +3298,7 @@ public class copybookParser extends Parser {
 		try {
 			enterOuterAlt(_localctx, 1);
 			{
-			setState(409);
+			setState(413);
 			_la = _input.LA(1);
 			if ( !(_la==LEVEL_ROOT || _la==LEVEL_REGULAR) ) {
 			_errHandler.recoverInline(this);
@@ -3325,7 +3343,7 @@ public class copybookParser extends Parser {
 		try {
 			enterOuterAlt(_localctx, 1);
 			{
-			setState(411);
+			setState(415);
 			_la = _input.LA(1);
 			if ( !((((_la) & ~0x3f) == 0 && ((1L << _la) & ((1L << SKIP1) | (1L << SKIP2) | (1L << SKIP3))) != 0)) ) {
 			_errHandler.recoverInline(this);
@@ -3400,21 +3418,21 @@ public class copybookParser extends Parser {
 		try {
 			enterOuterAlt(_localctx, 1);
 			{
-			setState(413);
+			setState(417);
 			section();
-			setState(414);
+			setState(418);
 			identifier();
-			setState(421);
+			setState(425);
 			_errHandler.sync(this);
 			_la = _input.LA(1);
 			while ((((_la) & ~0x3f) == 0 && ((1L << _la) & ((1L << BINARY) | (1L << COMP) | (1L << COMP_0) | (1L << COMP_3) | (1L << COMP_3U) | (1L << COMP_4) | (1L << COMP_5) | (1L << COMP_9) | (1L << COMPUTATIONAL) | (1L << COMPUTATIONAL_0) | (1L << COMPUTATIONAL_3) | (1L << COMPUTATIONAL_3U) | (1L << COMPUTATIONAL_4) | (1L << COMPUTATIONAL_5) | (1L << COMPUTATIONAL_9) | (1L << DISPLAY) | (1L << OCCURS) | (1L << PACKED_DECIMAL) | (1L << REDEFINES))) != 0) || ((((_la - 73)) & ~0x3f) == 0 && ((1L << (_la - 73)) & ((1L << (USAGE - 73)) | (1L << (VALUE - 73)) | (1L << (VALUES - 73)))) != 0)) {
 				{
-				setState(419);
+				setState(423);
 				_errHandler.sync(this);
 				switch (_input.LA(1)) {
 				case REDEFINES:
 					{
-					setState(415);
+					setState(419);
 					redefines();
 					}
 					break;
@@ -3437,20 +3455,20 @@ public class copybookParser extends Parser {
 				case PACKED_DECIMAL:
 				case USAGE:
 					{
-					setState(416);
+					setState(420);
 					usageGroup();
 					}
 					break;
 				case OCCURS:
 					{
-					setState(417);
+					setState(421);
 					occurs();
 					}
 					break;
 				case VALUE:
 				case VALUES:
 					{
-					setState(418);
+					setState(422);
 					values();
 					}
 					break;
@@ -3458,11 +3476,11 @@ public class copybookParser extends Parser {
 					throw new NoViableAltException(this);
 				}
 				}
-				setState(423);
+				setState(427);
 				_errHandler.sync(this);
 				_la = _input.LA(1);
 			}
-			setState(424);
+			setState(428);
 			term();
 			}
 		}
@@ -3550,89 +3568,89 @@ public class copybookParser extends Parser {
 		try {
 			enterOuterAlt(_localctx, 1);
 			{
-			setState(426);
+			setState(430);
 			section();
-			setState(427);
+			setState(431);
 			identifier();
-			setState(437);
+			setState(441);
 			_errHandler.sync(this);
 			_la = _input.LA(1);
 			while ((((_la) & ~0x3f) == 0 && ((1L << _la) & ((1L << BINARY) | (1L << COMP) | (1L << COMP_0) | (1L << COMP_1) | (1L << COMP_2) | (1L << COMP_3) | (1L << COMP_3U) | (1L << COMP_4) | (1L << COMP_5) | (1L << COMP_9) | (1L << COMPUTATIONAL) | (1L << COMPUTATIONAL_0) | (1L << COMPUTATIONAL_1) | (1L << COMPUTATIONAL_2) | (1L << COMPUTATIONAL_3) | (1L << COMPUTATIONAL_3U) | (1L << COMPUTATIONAL_4) | (1L << COMPUTATIONAL_5) | (1L << COMPUTATIONAL_9) | (1L << DISPLAY) | (1L << JUST) | (1L << JUSTIFIED) | (1L << OCCURS) | (1L << PACKED_DECIMAL) | (1L << PIC) | (1L << PICTURE) | (1L << REDEFINES))) != 0) || ((((_la - 64)) & ~0x3f) == 0 && ((1L << (_la - 64)) & ((1L << (SIGN - 64)) | (1L << (USAGE - 64)) | (1L << (VALUE - 64)) | (1L << (VALUES - 64)))) != 0)) {
 				{
-				setState(435);
+				setState(439);
 				_errHandler.sync(this);
-				switch ( getInterpreter().adaptivePredict(_input,49,_ctx) ) {
+				switch ( getInterpreter().adaptivePredict(_input,50,_ctx) ) {
 				case 1:
 					{
-					setState(428);
+					setState(432);
 					justified();
 					}
 					break;
 				case 2:
 					{
-					setState(429);
+					setState(433);
 					occurs();
 					}
 					break;
 				case 3:
 					{
-					setState(430);
+					setState(434);
 					pic();
 					}
 					break;
 				case 4:
 					{
-					setState(431);
+					setState(435);
 					redefines();
 					}
 					break;
 				case 5:
 					{
-					setState(432);
+					setState(436);
 					usage();
 					}
 					break;
 				case 6:
 					{
-					setState(433);
+					setState(437);
 					values();
 					}
 					break;
 				case 7:
 					{
-					setState(434);
+					setState(438);
 					separateSign();
 					}
 					break;
 				}
 				}
-				setState(439);
+				setState(443);
 				_errHandler.sync(this);
 				_la = _input.LA(1);
 			}
-			setState(445);
+			setState(449);
 			_errHandler.sync(this);
 			_la = _input.LA(1);
 			if (_la==BLANK) {
 				{
-				setState(440);
+				setState(444);
 				match(BLANK);
-				setState(442);
+				setState(446);
 				_errHandler.sync(this);
 				_la = _input.LA(1);
 				if (_la==WHEN) {
 					{
-					setState(441);
+					setState(445);
 					match(WHEN);
 					}
 				}
 
-				setState(444);
+				setState(448);
 				match(ZERO);
 				}
 			}
 
-			setState(447);
+			setState(451);
 			term();
 			}
 		}
@@ -3675,13 +3693,13 @@ public class copybookParser extends Parser {
 		try {
 			enterOuterAlt(_localctx, 1);
 			{
-			setState(449);
+			setState(453);
 			match(LEVEL_NUMBER_66);
-			setState(450);
+			setState(454);
 			identifier();
-			setState(451);
+			setState(455);
 			renames();
-			setState(452);
+			setState(456);
 			term();
 			}
 		}
@@ -3724,13 +3742,13 @@ public class copybookParser extends Parser {
 		try {
 			enterOuterAlt(_localctx, 1);
 			{
-			setState(454);
+			setState(458);
 			match(LEVEL_NUMBER_88);
-			setState(455);
+			setState(459);
 			identifier();
-			setState(456);
+			setState(460);
 			values();
-			setState(457);
+			setState(461);
 			term();
 			}
 		}
@@ -3780,55 +3798,55 @@ public class copybookParser extends Parser {
 		ItemContext _localctx = new ItemContext(_ctx, getState());
 		enterRule(_localctx, 80, RULE_item);
 		try {
-			setState(466);
+			setState(470);
 			_errHandler.sync(this);
-			switch ( getInterpreter().adaptivePredict(_input,53,_ctx) ) {
+			switch ( getInterpreter().adaptivePredict(_input,54,_ctx) ) {
 			case 1:
 				enterOuterAlt(_localctx, 1);
 				{
-				setState(459);
+				setState(463);
 				match(COMMENT);
 				}
 				break;
 			case 2:
 				enterOuterAlt(_localctx, 2);
 				{
-				setState(460);
+				setState(464);
 				group();
 				}
 				break;
 			case 3:
 				enterOuterAlt(_localctx, 3);
 				{
-				setState(461);
+				setState(465);
 				primitive();
 				}
 				break;
 			case 4:
 				enterOuterAlt(_localctx, 4);
 				{
-				setState(462);
+				setState(466);
 				level66statement();
 				}
 				break;
 			case 5:
 				enterOuterAlt(_localctx, 5);
 				{
-				setState(463);
+				setState(467);
 				level88statement();
 				}
 				break;
 			case 6:
 				enterOuterAlt(_localctx, 6);
 				{
-				setState(464);
+				setState(468);
 				skipLiteral();
 				}
 				break;
 			case 7:
 				enterOuterAlt(_localctx, 7);
 				{
-				setState(465);
+				setState(469);
 				term();
 				}
 				break;
@@ -3846,206 +3864,207 @@ public class copybookParser extends Parser {
 	}
 
 	public static final String _serializedATN =
-		"\3\u608b\ua72a\u8133\ub9ed\u417c\u3be7\u7786\u5964\3\u008a\u01d7\4\2\t"+
+		"\3\u608b\ua72a\u8133\ub9ed\u417c\u3be7\u7786\u5964\3\u008a\u01db\4\2\t"+
 		"\2\4\3\t\3\4\4\t\4\4\5\t\5\4\6\t\6\4\7\t\7\4\b\t\b\4\t\t\t\4\n\t\n\4\13"+
 		"\t\13\4\f\t\f\4\r\t\r\4\16\t\16\4\17\t\17\4\20\t\20\4\21\t\21\4\22\t\22"+
 		"\4\23\t\23\4\24\t\24\4\25\t\25\4\26\t\26\4\27\t\27\4\30\t\30\4\31\t\31"+
 		"\4\32\t\32\4\33\t\33\4\34\t\34\4\35\t\35\4\36\t\36\4\37\t\37\4 \t \4!"+
 		"\t!\4\"\t\"\4#\t#\4$\t$\4%\t%\4&\t&\4\'\t\'\4(\t(\4)\t)\4*\t*\3\2\6\2"+
 		"V\n\2\r\2\16\2W\3\2\5\2[\n\2\3\2\3\2\3\3\3\3\3\3\3\3\5\3c\n\3\3\4\5\4"+
-		"f\n\4\3\4\3\4\3\4\5\4k\n\4\3\4\5\4n\n\4\3\5\3\5\3\6\3\6\3\7\3\7\3\7\3"+
-		"\7\3\7\3\7\3\7\3\7\3\7\3\7\3\7\3\7\3\7\3\7\3\7\3\7\3\7\3\7\3\7\3\7\3\7"+
+		"f\n\4\3\4\3\4\3\4\5\4k\n\4\3\4\3\4\5\4o\n\4\3\4\5\4r\n\4\3\5\3\5\3\6\3"+
+		"\6\3\7\3\7\3\7\3\7\3\7\3\7\3\7\3\7\3\7\3\7\3\7\3\7\3\7\3\7\3\7\3\7\3\7"+
 		"\3\7\3\7\3\7\3\7\3\7\3\7\3\7\3\7\3\7\3\7\3\7\3\7\3\7\3\7\3\7\3\7\3\7\3"+
 		"\7\3\7\3\7\3\7\3\7\3\7\3\7\3\7\3\7\3\7\3\7\3\7\3\7\3\7\3\7\3\7\3\7\3\7"+
 		"\3\7\3\7\3\7\3\7\3\7\3\7\3\7\3\7\3\7\3\7\3\7\3\7\3\7\3\7\3\7\3\7\3\7\3"+
-		"\7\3\7\3\7\3\7\3\7\3\7\3\7\3\7\3\7\5\7\u00c6\n\7\3\b\3\b\3\t\3\t\5\t\u00cc"+
-		"\n\t\3\t\3\t\5\t\u00d0\n\t\5\t\u00d2\n\t\3\t\3\t\5\t\u00d6\n\t\3\t\7\t"+
-		"\u00d9\n\t\f\t\16\t\u00dc\13\t\3\n\3\n\5\n\u00e0\n\n\3\13\3\13\3\f\3\f"+
-		"\3\f\3\r\3\r\3\r\3\r\3\r\3\r\3\r\3\r\3\r\3\r\3\r\3\r\3\r\3\r\3\r\5\r\u00f6"+
-		"\n\r\3\16\3\16\5\16\u00fa\n\16\3\16\5\16\u00fd\n\16\3\16\3\16\3\17\3\17"+
-		"\3\17\3\20\3\20\5\20\u0106\n\20\3\20\3\20\3\21\3\21\5\21\u010c\n\21\3"+
-		"\21\3\21\5\21\u0110\n\21\3\21\7\21\u0113\n\21\f\21\16\21\u0116\13\21\3"+
-		"\22\3\22\3\22\5\22\u011b\n\22\3\22\5\22\u011e\n\22\3\22\5\22\u0121\n\22"+
-		"\3\22\5\22\u0124\n\22\3\22\5\22\u0127\n\22\3\23\3\23\3\23\3\24\3\24\3"+
-		"\24\3\24\3\24\5\24\u0131\n\24\3\25\3\25\3\26\3\26\3\27\3\27\5\27\u0139"+
-		"\n\27\5\27\u013b\n\27\3\27\3\27\3\30\3\30\5\30\u0141\n\30\5\30\u0143\n"+
-		"\30\3\30\3\30\3\31\3\31\5\31\u0149\n\31\3\31\3\31\5\31\u014d\n\31\3\31"+
-		"\5\31\u0150\n\31\3\32\3\32\5\32\u0154\n\32\3\33\3\33\3\34\3\34\5\34\u015a"+
-		"\n\34\3\35\3\35\3\35\3\35\3\35\3\35\3\35\3\35\3\35\3\35\3\35\3\35\3\35"+
-		"\5\35\u0169\n\35\3\36\5\36\u016c\n\36\3\36\3\36\3\36\3\36\5\36\u0172\n"+
-		"\36\3\37\3\37\3 \3 \3!\3!\3\"\3\"\3#\3#\3#\3#\3#\3#\5#\u0182\n#\3#\5#"+
-		"\u0185\n#\3#\5#\u0188\n#\5#\u018a\n#\3#\3#\5#\u018e\n#\5#\u0190\n#\3#"+
-		"\3#\3#\5#\u0195\n#\5#\u0197\n#\3#\5#\u019a\n#\3$\3$\3%\3%\3&\3&\3&\3&"+
-		"\3&\3&\7&\u01a6\n&\f&\16&\u01a9\13&\3&\3&\3\'\3\'\3\'\3\'\3\'\3\'\3\'"+
-		"\3\'\3\'\7\'\u01b6\n\'\f\'\16\'\u01b9\13\'\3\'\3\'\5\'\u01bd\n\'\3\'\5"+
-		"\'\u01c0\n\'\3\'\3\'\3(\3(\3(\3(\3(\3)\3)\3)\3)\3)\3*\3*\3*\3*\3*\3*\3"+
-		"*\5*\u01d5\n*\3*\2\2+\2\4\6\b\n\f\16\20\22\24\26\30\32\34\36 \"$&(*,."+
-		"\60\62\64\668:<>@BDFHJLNPR\2\17\4\2^^\177\u0084\4\2##JJ\4\2\6\6  \6\2"+
-		"\7\7\f\35!!\66\66\b\2\7\7\f\r\20\26\31\35!!\66\66\4\2,,II\3\2)*\4\2aa"+
-		"xx\4\2bbzz\4\2__tt\3\2\678\3\2\177\u0080\3\2?A\2\u025c\2U\3\2\2\2\4b\3"+
-		"\2\2\2\6m\3\2\2\2\bo\3\2\2\2\nq\3\2\2\2\f\u00c5\3\2\2\2\16\u00c7\3\2\2"+
-		"\2\20\u00d1\3\2\2\2\22\u00dd\3\2\2\2\24\u00e1\3\2\2\2\26\u00e3\3\2\2\2"+
-		"\30\u00f5\3\2\2\2\32\u00f7\3\2\2\2\34\u0100\3\2\2\2\36\u0103\3\2\2\2 "+
-		"\u0109\3\2\2\2\"\u0117\3\2\2\2$\u0128\3\2\2\2&\u012b\3\2\2\2(\u0132\3"+
-		"\2\2\2*\u0134\3\2\2\2,\u013a\3\2\2\2.\u0142\3\2\2\2\60\u0146\3\2\2\2\62"+
-		"\u0151\3\2\2\2\64\u0155\3\2\2\2\66\u0159\3\2\2\28\u0168\3\2\2\2:\u0171"+
-		"\3\2\2\2<\u0173\3\2\2\2>\u0175\3\2\2\2@\u0177\3\2\2\2B\u0179\3\2\2\2D"+
-		"\u0199\3\2\2\2F\u019b\3\2\2\2H\u019d\3\2\2\2J\u019f\3\2\2\2L\u01ac\3\2"+
-		"\2\2N\u01c3\3\2\2\2P\u01c8\3\2\2\2R\u01d4\3\2\2\2TV\5R*\2UT\3\2\2\2VW"+
-		"\3\2\2\2WU\3\2\2\2WX\3\2\2\2XZ\3\2\2\2Y[\7\u0089\2\2ZY\3\2\2\2Z[\3\2\2"+
-		"\2[\\\3\2\2\2\\]\7\2\2\3]\3\3\2\2\2^c\7~\2\2_c\5\6\4\2`c\5\n\6\2ac\5\30"+
-		"\r\2b^\3\2\2\2b_\3\2\2\2b`\3\2\2\2ba\3\2\2\2c\5\3\2\2\2df\5\66\34\2ed"+
-		"\3\2\2\2ef\3\2\2\2fg\3\2\2\2gn\7\u0086\2\2hn\7P\2\2ik\5\66\34\2ji\3\2"+
-		"\2\2jk\3\2\2\2kl\3\2\2\2ln\5\b\5\2me\3\2\2\2mh\3\2\2\2mj\3\2\2\2n\7\3"+
-		"\2\2\2op\t\2\2\2p\t\3\2\2\2qr\t\3\2\2r\13\3\2\2\2s\u00c6\7\u0088\2\2t"+
-		"\u00c6\7\3\2\2u\u00c6\7_\2\2v\u00c6\7`\2\2w\u00c6\7f\2\2x\u00c6\7a\2\2"+
-		"y\u00c6\3\2\2\2z\u00c6\7b\2\2{\u00c6\7c\2\2|\u00c6\7g\2\2}\u00c6\7d\2"+
-		"\2~\u00c6\7h\2\2\177\u00c6\7e\2\2\u0080\u00c6\7i\2\2\u0081\u00c6\7\u0087"+
-		"\2\2\u0082\u00c6\7B\2\2\u0083\u00c6\7,\2\2\u0084\u00c6\7I\2\2\u0085\u00c6"+
-		"\7>\2\2\u0086\u00c6\7\n\2\2\u0087\u00c6\7\6\2\2\u0088\u00c6\7 \2\2\u0089"+
-		"\u00c6\7+\2\2\u008a\u00c6\7\7\2\2\u008b\u00c6\7!\2\2\u008c\u00c6\7\66"+
-		"\2\2\u008d\u00c6\7\25\2\2\u008e\u00c6\7\26\2\2\u008f\u00c6\7\27\2\2\u0090"+
-		"\u00c6\7\30\2\2\u0091\u00c6\7\31\2\2\u0092\u00c6\7\32\2\2\u0093\u00c6"+
-		"\7\33\2\2\u0094\u00c6\7\34\2\2\u0095\u00c6\7\35\2\2\u0096\u00c6\7\f\2"+
-		"\2\u0097\u00c6\7\r\2\2\u0098\u00c6\7\16\2\2\u0099\u00c6\7\17\2\2\u009a"+
-		"\u00c6\7\20\2\2\u009b\u00c6\7\21\2\2\u009c\u00c6\7\22\2\2\u009d\u00c6"+
-		"\7\23\2\2\u009e\u00c6\7\24\2\2\u009f\u00c6\7;\2\2\u00a0\u00c6\7<\2\2\u00a1"+
-		"\u00c6\7M\2\2\u00a2\u00c6\7N\2\2\u00a3\u00c6\7\64\2\2\u00a4\u00c6\7G\2"+
-		"\2\u00a5\u00c6\7\37\2\2\u00a6\u00c6\7\'\2\2\u00a7\u00c6\7\b\2\2\u00a8"+
-		"\u00c6\7P\2\2\u00a9\u00c6\7Q\2\2\u00aa\u00c6\7R\2\2\u00ab\u00c6\7C\2\2"+
-		"\u00ac\u00c6\7D\2\2\u00ad\u00c6\7%\2\2\u00ae\u00c6\7&\2\2\u00af\u00c6"+
-		"\7.\2\2\u00b0\u00c6\7/\2\2\u00b1\u00c6\7\60\2\2\u00b2\u00c6\7\61\2\2\u00b3"+
-		"\u00c6\79\2\2\u00b4\u00c6\7:\2\2\u00b5\u00c6\7*\2\2\u00b6\u00c6\7)\2\2"+
-		"\u00b7\u00c6\7=\2\2\u00b8\u00c6\78\2\2\u00b9\u00c6\7\67\2\2\u00ba\u00c6"+
-		"\7J\2\2\u00bb\u00c6\7#\2\2\u00bc\u00c6\7\5\2\2\u00bd\u00c6\7(\2\2\u00be"+
-		"\u00c6\7\65\2\2\u00bf\u00c6\7\t\2\2\u00c0\u00c6\7O\2\2\u00c1\u00c6\7H"+
-		"\2\2\u00c2\u00c6\7\4\2\2\u00c3\u00c6\7K\2\2\u00c4\u00c6\7$\2\2\u00c5s"+
-		"\3\2\2\2\u00c5t\3\2\2\2\u00c5u\3\2\2\2\u00c5v\3\2\2\2\u00c5w\3\2\2\2\u00c5"+
-		"x\3\2\2\2\u00c5y\3\2\2\2\u00c5z\3\2\2\2\u00c5{\3\2\2\2\u00c5|\3\2\2\2"+
-		"\u00c5}\3\2\2\2\u00c5~\3\2\2\2\u00c5\177\3\2\2\2\u00c5\u0080\3\2\2\2\u00c5"+
-		"\u0081\3\2\2\2\u00c5\u0082\3\2\2\2\u00c5\u0083\3\2\2\2\u00c5\u0084\3\2"+
-		"\2\2\u00c5\u0085\3\2\2\2\u00c5\u0086\3\2\2\2\u00c5\u0087\3\2\2\2\u00c5"+
-		"\u0088\3\2\2\2\u00c5\u0089\3\2\2\2\u00c5\u008a\3\2\2\2\u00c5\u008b\3\2"+
-		"\2\2\u00c5\u008c\3\2\2\2\u00c5\u008d\3\2\2\2\u00c5\u008e\3\2\2\2\u00c5"+
-		"\u008f\3\2\2\2\u00c5\u0090\3\2\2\2\u00c5\u0091\3\2\2\2\u00c5\u0092\3\2"+
-		"\2\2\u00c5\u0093\3\2\2\2\u00c5\u0094\3\2\2\2\u00c5\u0095\3\2\2\2\u00c5"+
-		"\u0096\3\2\2\2\u00c5\u0097\3\2\2\2\u00c5\u0098\3\2\2\2\u00c5\u0099\3\2"+
-		"\2\2\u00c5\u009a\3\2\2\2\u00c5\u009b\3\2\2\2\u00c5\u009c\3\2\2\2\u00c5"+
-		"\u009d\3\2\2\2\u00c5\u009e\3\2\2\2\u00c5\u009f\3\2\2\2\u00c5\u00a0\3\2"+
-		"\2\2\u00c5\u00a1\3\2\2\2\u00c5\u00a2\3\2\2\2\u00c5\u00a3\3\2\2\2\u00c5"+
-		"\u00a4\3\2\2\2\u00c5\u00a5\3\2\2\2\u00c5\u00a6\3\2\2\2\u00c5\u00a7\3\2"+
-		"\2\2\u00c5\u00a8\3\2\2\2\u00c5\u00a9\3\2\2\2\u00c5\u00aa\3\2\2\2\u00c5"+
-		"\u00ab\3\2\2\2\u00c5\u00ac\3\2\2\2\u00c5\u00ad\3\2\2\2\u00c5\u00ae\3\2"+
-		"\2\2\u00c5\u00af\3\2\2\2\u00c5\u00b0\3\2\2\2\u00c5\u00b1\3\2\2\2\u00c5"+
-		"\u00b2\3\2\2\2\u00c5\u00b3\3\2\2\2\u00c5\u00b4\3\2\2\2\u00c5\u00b5\3\2"+
-		"\2\2\u00c5\u00b6\3\2\2\2\u00c5\u00b7\3\2\2\2\u00c5\u00b8\3\2\2\2\u00c5"+
-		"\u00b9\3\2\2\2\u00c5\u00ba\3\2\2\2\u00c5\u00bb\3\2\2\2\u00c5\u00bc\3\2"+
-		"\2\2\u00c5\u00bd\3\2\2\2\u00c5\u00be\3\2\2\2\u00c5\u00bf\3\2\2\2\u00c5"+
-		"\u00c0\3\2\2\2\u00c5\u00c1\3\2\2\2\u00c5\u00c2\3\2\2\2\u00c5\u00c3\3\2"+
-		"\2\2\u00c5\u00c4\3\2\2\2\u00c6\r\3\2\2\2\u00c7\u00c8\7\3\2\2\u00c8\17"+
-		"\3\2\2\2\u00c9\u00cb\7M\2\2\u00ca\u00cc\7(\2\2\u00cb\u00ca\3\2\2\2\u00cb"+
-		"\u00cc\3\2\2\2\u00cc\u00d2\3\2\2\2\u00cd\u00cf\7N\2\2\u00ce\u00d0\7\5"+
-		"\2\2\u00cf\u00ce\3\2\2\2\u00cf\u00d0\3\2\2\2\u00d0\u00d2\3\2\2\2\u00d1"+
-		"\u00c9\3\2\2\2\u00d1\u00cd\3\2\2\2\u00d2\u00d3\3\2\2\2\u00d3\u00da\5\22"+
-		"\n\2\u00d4\u00d6\7T\2\2\u00d5\u00d4\3\2\2\2\u00d5\u00d6\3\2\2\2\u00d6"+
-		"\u00d7\3\2\2\2\u00d7\u00d9\5\22\n\2\u00d8\u00d5\3\2\2\2\u00d9\u00dc\3"+
-		"\2\2\2\u00da\u00d8\3\2\2\2\u00da\u00db\3\2\2\2\u00db\21\3\2\2\2\u00dc"+
-		"\u00da\3\2\2\2\u00dd\u00df\5\24\13\2\u00de\u00e0\5\26\f\2\u00df\u00de"+
-		"\3\2\2\2\u00df\u00e0\3\2\2\2\u00e0\23\3\2\2\2\u00e1\u00e2\5\4\3\2\u00e2"+
-		"\25\3\2\2\2\u00e3\u00e4\5\16\b\2\u00e4\u00e5\5\4\3\2\u00e5\27\3\2\2\2"+
-		"\u00e6\u00e7\7\4\2\2\u00e7\u00f6\5\4\3\2\u00e8\u00f6\7%\2\2\u00e9\u00f6"+
-		"\7&\2\2\u00ea\u00f6\7.\2\2\u00eb\u00f6\7/\2\2\u00ec\u00f6\7\60\2\2\u00ed"+
-		"\u00f6\7\61\2\2\u00ee\u00f6\79\2\2\u00ef\u00f6\7:\2\2\u00f0\u00f6\7C\2"+
-		"\2\u00f1\u00f6\7D\2\2\u00f2\u00f6\7P\2\2\u00f3\u00f6\7Q\2\2\u00f4\u00f6"+
-		"\7R\2\2\u00f5\u00e6\3\2\2\2\u00f5\u00e8\3\2\2\2\u00f5\u00e9\3\2\2\2\u00f5"+
-		"\u00ea\3\2\2\2\u00f5\u00eb\3\2\2\2\u00f5\u00ec\3\2\2\2\u00f5\u00ed\3\2"+
-		"\2\2\u00f5\u00ee\3\2\2\2\u00f5\u00ef\3\2\2\2\u00f5\u00f0\3\2\2\2\u00f5"+
-		"\u00f1\3\2\2\2\u00f5\u00f2\3\2\2\2\u00f5\u00f3\3\2\2\2\u00f5\u00f4\3\2"+
-		"\2\2\u00f6\31\3\2\2\2\u00f7\u00f9\t\4\2\2\u00f8\u00fa\7+\2\2\u00f9\u00f8"+
-		"\3\2\2\2\u00f9\u00fa\3\2\2\2\u00fa\u00fc\3\2\2\2\u00fb\u00fd\7(\2\2\u00fc"+
-		"\u00fb\3\2\2\2\u00fc\u00fd\3\2\2\2\u00fd\u00fe\3\2\2\2\u00fe\u00ff\5\f"+
-		"\7\2\u00ff\33\3\2\2\2\u0100\u0101\7H\2\2\u0101\u0102\5\b\5\2\u0102\35"+
-		"\3\2\2\2\u0103\u0105\7\37\2\2\u0104\u0106\7\65\2\2\u0105\u0104\3\2\2\2"+
-		"\u0105\u0106\3\2\2\2\u0106\u0107\3\2\2\2\u0107\u0108\5\f\7\2\u0108\37"+
-		"\3\2\2\2\u0109\u010b\7\'\2\2\u010a\u010c\7\t\2\2\u010b\u010a\3\2\2\2\u010b"+
-		"\u010c\3\2\2\2\u010c\u010d\3\2\2\2\u010d\u0114\5\f\7\2\u010e\u0110\7T"+
-		"\2\2\u010f\u010e\3\2\2\2\u010f\u0110\3\2\2\2\u0110\u0111\3\2\2\2\u0111"+
-		"\u0113\7\u0088\2\2\u0112\u010f\3\2\2\2\u0113\u0116\3\2\2\2\u0114\u0112"+
-		"\3\2\2\2\u0114\u0115\3\2\2\2\u0115!\3\2\2\2\u0116\u0114\3\2\2\2\u0117"+
-		"\u0118\7\64\2\2\u0118\u011a\5\b\5\2\u0119\u011b\5\34\17\2\u011a\u0119"+
-		"\3\2\2\2\u011a\u011b\3\2\2\2\u011b\u011d\3\2\2\2\u011c\u011e\7G\2\2\u011d"+
-		"\u011c\3\2\2\2\u011d\u011e\3\2\2\2\u011e\u0120\3\2\2\2\u011f\u0121\5\36"+
-		"\20\2\u0120\u011f\3\2\2\2\u0120\u0121\3\2\2\2\u0121\u0123\3\2\2\2\u0122"+
-		"\u0124\5\32\16\2\u0123\u0122\3\2\2\2\u0123\u0124\3\2\2\2\u0124\u0126\3"+
-		"\2\2\2\u0125\u0127\5 \21\2\u0126\u0125\3\2\2\2\u0126\u0127\3\2\2\2\u0127"+
-		"#\3\2\2\2\u0128\u0129\7;\2\2\u0129\u012a\5\f\7\2\u012a%\3\2\2\2\u012b"+
-		"\u012c\7<\2\2\u012c\u0130\5\f\7\2\u012d\u012e\5\16\b\2\u012e\u012f\5\f"+
-		"\7\2\u012f\u0131\3\2\2\2\u0130\u012d\3\2\2\2\u0130\u0131\3\2\2\2\u0131"+
-		"\'\3\2\2\2\u0132\u0133\t\5\2\2\u0133)\3\2\2\2\u0134\u0135\t\6\2\2\u0135"+
-		"+\3\2\2\2\u0136\u0138\7K\2\2\u0137\u0139\7(\2\2\u0138\u0137\3\2\2\2\u0138"+
-		"\u0139\3\2\2\2\u0139\u013b\3\2\2\2\u013a\u0136\3\2\2\2\u013a\u013b\3\2"+
-		"\2\2\u013b\u013c\3\2\2\2\u013c\u013d\5(\25\2\u013d-\3\2\2\2\u013e\u0140"+
-		"\7K\2\2\u013f\u0141\7(\2\2\u0140\u013f\3\2\2\2\u0140\u0141\3\2\2\2\u0141"+
-		"\u0143\3\2\2\2\u0142\u013e\3\2\2\2\u0142\u0143\3\2\2\2\u0143\u0144\3\2"+
-		"\2\2\u0144\u0145\5*\26\2\u0145/\3\2\2\2\u0146\u0148\7B\2\2\u0147\u0149"+
-		"\7(\2\2\u0148\u0147\3\2\2\2\u0148\u0149\3\2\2\2\u0149\u014a\3\2\2\2\u014a"+
-		"\u014c\t\7\2\2\u014b\u014d\7>\2\2\u014c\u014b\3\2\2\2\u014c\u014d\3\2"+
-		"\2\2\u014d\u014f\3\2\2\2\u014e\u0150\7\n\2\2\u014f\u014e\3\2\2\2\u014f"+
-		"\u0150\3\2\2\2\u0150\61\3\2\2\2\u0151\u0153\t\b\2\2\u0152\u0154\7=\2\2"+
-		"\u0153\u0152\3\2\2\2\u0153\u0154\3\2\2\2\u0154\63\3\2\2\2\u0155\u0156"+
-		"\7\\\2\2\u0156\65\3\2\2\2\u0157\u015a\7X\2\2\u0158\u015a\7W\2\2\u0159"+
-		"\u0157\3\2\2\2\u0159\u0158\3\2\2\2\u015a\67\3\2\2\2\u015b\u0169\7^\2\2"+
-		"\u015c\u0169\7c\2\2\u015d\u0169\7`\2\2\u015e\u0169\7d\2\2\u015f\u0169"+
-		"\7e\2\2\u0160\u0169\7j\2\2\u0161\u0169\7k\2\2\u0162\u0169\7l\2\2\u0163"+
-		"\u0169\7m\2\2\u0164\u0169\7n\2\2\u0165\u0169\7o\2\2\u0166\u0169\7p\2\2"+
-		"\u0167\u0169\7q\2\2\u0168\u015b\3\2\2\2\u0168\u015c\3\2\2\2\u0168\u015d"+
-		"\3\2\2\2\u0168\u015e\3\2\2\2\u0168\u015f\3\2\2\2\u0168\u0160\3\2\2\2\u0168"+
-		"\u0161\3\2\2\2\u0168\u0162\3\2\2\2\u0168\u0163\3\2\2\2\u0168\u0164\3\2"+
-		"\2\2\u0168\u0165\3\2\2\2\u0168\u0166\3\2\2\2\u0168\u0167\3\2\2\2\u0169"+
-		"9\3\2\2\2\u016a\u016c\5\66\34\2\u016b\u016a\3\2\2\2\u016b\u016c\3\2\2"+
-		"\2\u016c\u016d\3\2\2\2\u016d\u0172\58\35\2\u016e\u016f\58\35\2\u016f\u0170"+
-		"\5\66\34\2\u0170\u0172\3\2\2\2\u0171\u016b\3\2\2\2\u0171\u016e\3\2\2\2"+
-		"\u0172;\3\2\2\2\u0173\u0174\t\t\2\2\u0174=\3\2\2\2\u0175\u0176\t\n\2\2"+
-		"\u0176?\3\2\2\2\u0177\u0178\t\13\2\2\u0178A\3\2\2\2\u0179\u017a\t\f\2"+
-		"\2\u017aC\3\2\2\2\u017b\u0189\5B\"\2\u017c\u018a\5<\37\2\u017d\u018a\5"+
-		"@!\2\u017e\u018a\5> \2\u017f\u0181\5:\36\2\u0180\u0182\5,\27\2\u0181\u0180"+
-		"\3\2\2\2\u0181\u0182\3\2\2\2\u0182\u0188\3\2\2\2\u0183\u0185\5,\27\2\u0184"+
-		"\u0183\3\2\2\2\u0184\u0185\3\2\2\2\u0185\u0186\3\2\2\2\u0186\u0188\5:"+
-		"\36\2\u0187\u017f\3\2\2\2\u0187\u0184\3\2\2\2\u0188\u018a\3\2\2\2\u0189"+
-		"\u017c\3\2\2\2\u0189\u017d\3\2\2\2\u0189\u017e\3\2\2\2\u0189\u0187\3\2"+
-		"\2\2\u018a\u019a\3\2\2\2\u018b\u018d\7K\2\2\u018c\u018e\7(\2\2\u018d\u018c"+
-		"\3\2\2\2\u018d\u018e\3\2\2\2\u018e\u0190\3\2\2\2\u018f\u018b\3\2\2\2\u018f"+
-		"\u0190\3\2\2\2\u0190\u0191\3\2\2\2\u0191\u019a\7\16\2\2\u0192\u0194\7"+
-		"K\2\2\u0193\u0195\7(\2\2\u0194\u0193\3\2\2\2\u0194\u0195\3\2\2\2\u0195"+
-		"\u0197\3\2\2\2\u0196\u0192\3\2\2\2\u0196\u0197\3\2\2\2\u0197\u0198\3\2"+
-		"\2\2\u0198\u019a\7\17\2\2\u0199\u017b\3\2\2\2\u0199\u018f\3\2\2\2\u0199"+
-		"\u0196\3\2\2\2\u019aE\3\2\2\2\u019b\u019c\t\r\2\2\u019cG\3\2\2\2\u019d"+
-		"\u019e\t\16\2\2\u019eI\3\2\2\2\u019f\u01a0\5F$\2\u01a0\u01a7\5\f\7\2\u01a1"+
-		"\u01a6\5$\23\2\u01a2\u01a6\5.\30\2\u01a3\u01a6\5\"\22\2\u01a4\u01a6\5"+
-		"\20\t\2\u01a5\u01a1\3\2\2\2\u01a5\u01a2\3\2\2\2\u01a5\u01a3\3\2\2\2\u01a5"+
-		"\u01a4\3\2\2\2\u01a6\u01a9\3\2\2\2\u01a7\u01a5\3\2\2\2\u01a7\u01a8\3\2"+
-		"\2\2\u01a8\u01aa\3\2\2\2\u01a9\u01a7\3\2\2\2\u01aa\u01ab\5\64\33\2\u01ab"+
-		"K\3\2\2\2\u01ac\u01ad\5F$\2\u01ad\u01b7\5\f\7\2\u01ae\u01b6\5\62\32\2"+
-		"\u01af\u01b6\5\"\22\2\u01b0\u01b6\5D#\2\u01b1\u01b6\5$\23\2\u01b2\u01b6"+
-		"\5,\27\2\u01b3\u01b6\5\20\t\2\u01b4\u01b6\5\60\31\2\u01b5\u01ae\3\2\2"+
-		"\2\u01b5\u01af\3\2\2\2\u01b5\u01b0\3\2\2\2\u01b5\u01b1\3\2\2\2\u01b5\u01b2"+
-		"\3\2\2\2\u01b5\u01b3\3\2\2\2\u01b5\u01b4\3\2\2\2\u01b6\u01b9\3\2\2\2\u01b7"+
-		"\u01b5\3\2\2\2\u01b7\u01b8\3\2\2\2\u01b8\u01bf\3\2\2\2\u01b9\u01b7\3\2"+
-		"\2\2\u01ba\u01bc\7\b\2\2\u01bb\u01bd\7O\2\2\u01bc\u01bb\3\2\2\2\u01bc"+
-		"\u01bd\3\2\2\2\u01bd\u01be\3\2\2\2\u01be\u01c0\7P\2\2\u01bf\u01ba\3\2"+
-		"\2\2\u01bf\u01c0\3\2\2\2\u01c0\u01c1\3\2\2\2\u01c1\u01c2\5\64\33\2\u01c2"+
-		"M\3\2\2\2\u01c3\u01c4\7\u0081\2\2\u01c4\u01c5\5\f\7\2\u01c5\u01c6\5&\24"+
-		"\2\u01c6\u01c7\5\64\33\2\u01c7O\3\2\2\2\u01c8\u01c9\7\u0083\2\2\u01c9"+
-		"\u01ca\5\f\7\2\u01ca\u01cb\5\20\t\2\u01cb\u01cc\5\64\33\2\u01ccQ\3\2\2"+
-		"\2\u01cd\u01d5\7]\2\2\u01ce\u01d5\5J&\2\u01cf\u01d5\5L\'\2\u01d0\u01d5"+
-		"\5N(\2\u01d1\u01d5\5P)\2\u01d2\u01d5\5H%\2\u01d3\u01d5\5\64\33\2\u01d4"+
-		"\u01cd\3\2\2\2\u01d4\u01ce\3\2\2\2\u01d4\u01cf\3\2\2\2\u01d4\u01d0\3\2"+
-		"\2\2\u01d4\u01d1\3\2\2\2\u01d4\u01d2\3\2\2\2\u01d4\u01d3\3\2\2\2\u01d5"+
-		"S\3\2\2\28WZbejm\u00c5\u00cb\u00cf\u00d1\u00d5\u00da\u00df\u00f5\u00f9"+
-		"\u00fc\u0105\u010b\u010f\u0114\u011a\u011d\u0120\u0123\u0126\u0130\u0138"+
-		"\u013a\u0140\u0142\u0148\u014c\u014f\u0153\u0159\u0168\u016b\u0171\u0181"+
-		"\u0184\u0187\u0189\u018d\u018f\u0194\u0196\u0199\u01a5\u01a7\u01b5\u01b7"+
-		"\u01bc\u01bf\u01d4";
+		"\7\3\7\3\7\3\7\3\7\3\7\3\7\3\7\3\7\3\7\3\7\3\7\3\7\5\7\u00ca\n\7\3\b\3"+
+		"\b\3\t\3\t\5\t\u00d0\n\t\3\t\3\t\5\t\u00d4\n\t\5\t\u00d6\n\t\3\t\3\t\5"+
+		"\t\u00da\n\t\3\t\7\t\u00dd\n\t\f\t\16\t\u00e0\13\t\3\n\3\n\5\n\u00e4\n"+
+		"\n\3\13\3\13\3\f\3\f\3\f\3\r\3\r\3\r\3\r\3\r\3\r\3\r\3\r\3\r\3\r\3\r\3"+
+		"\r\3\r\3\r\3\r\5\r\u00fa\n\r\3\16\3\16\5\16\u00fe\n\16\3\16\5\16\u0101"+
+		"\n\16\3\16\3\16\3\17\3\17\3\17\3\20\3\20\5\20\u010a\n\20\3\20\3\20\3\21"+
+		"\3\21\5\21\u0110\n\21\3\21\3\21\5\21\u0114\n\21\3\21\7\21\u0117\n\21\f"+
+		"\21\16\21\u011a\13\21\3\22\3\22\3\22\5\22\u011f\n\22\3\22\5\22\u0122\n"+
+		"\22\3\22\5\22\u0125\n\22\3\22\5\22\u0128\n\22\3\22\5\22\u012b\n\22\3\23"+
+		"\3\23\3\23\3\24\3\24\3\24\3\24\3\24\5\24\u0135\n\24\3\25\3\25\3\26\3\26"+
+		"\3\27\3\27\5\27\u013d\n\27\5\27\u013f\n\27\3\27\3\27\3\30\3\30\5\30\u0145"+
+		"\n\30\5\30\u0147\n\30\3\30\3\30\3\31\3\31\5\31\u014d\n\31\3\31\3\31\5"+
+		"\31\u0151\n\31\3\31\5\31\u0154\n\31\3\32\3\32\5\32\u0158\n\32\3\33\3\33"+
+		"\3\34\3\34\5\34\u015e\n\34\3\35\3\35\3\35\3\35\3\35\3\35\3\35\3\35\3\35"+
+		"\3\35\3\35\3\35\3\35\5\35\u016d\n\35\3\36\5\36\u0170\n\36\3\36\3\36\3"+
+		"\36\3\36\5\36\u0176\n\36\3\37\3\37\3 \3 \3!\3!\3\"\3\"\3#\3#\3#\3#\3#"+
+		"\3#\5#\u0186\n#\3#\5#\u0189\n#\3#\5#\u018c\n#\5#\u018e\n#\3#\3#\5#\u0192"+
+		"\n#\5#\u0194\n#\3#\3#\3#\5#\u0199\n#\5#\u019b\n#\3#\5#\u019e\n#\3$\3$"+
+		"\3%\3%\3&\3&\3&\3&\3&\3&\7&\u01aa\n&\f&\16&\u01ad\13&\3&\3&\3\'\3\'\3"+
+		"\'\3\'\3\'\3\'\3\'\3\'\3\'\7\'\u01ba\n\'\f\'\16\'\u01bd\13\'\3\'\3\'\5"+
+		"\'\u01c1\n\'\3\'\5\'\u01c4\n\'\3\'\3\'\3(\3(\3(\3(\3(\3)\3)\3)\3)\3)\3"+
+		"*\3*\3*\3*\3*\3*\3*\5*\u01d9\n*\3*\2\2+\2\4\6\b\n\f\16\20\22\24\26\30"+
+		"\32\34\36 \"$&(*,.\60\62\64\668:<>@BDFHJLNPR\2\17\4\2^^\177\u0084\4\2"+
+		"##JJ\4\2\6\6  \6\2\7\7\f\35!!\66\66\b\2\7\7\f\r\20\26\31\35!!\66\66\4"+
+		"\2,,II\3\2)*\4\2aaxx\4\2bbzz\4\2__tt\3\2\678\3\2\177\u0080\3\2?A\2\u0262"+
+		"\2U\3\2\2\2\4b\3\2\2\2\6q\3\2\2\2\bs\3\2\2\2\nu\3\2\2\2\f\u00c9\3\2\2"+
+		"\2\16\u00cb\3\2\2\2\20\u00d5\3\2\2\2\22\u00e1\3\2\2\2\24\u00e5\3\2\2\2"+
+		"\26\u00e7\3\2\2\2\30\u00f9\3\2\2\2\32\u00fb\3\2\2\2\34\u0104\3\2\2\2\36"+
+		"\u0107\3\2\2\2 \u010d\3\2\2\2\"\u011b\3\2\2\2$\u012c\3\2\2\2&\u012f\3"+
+		"\2\2\2(\u0136\3\2\2\2*\u0138\3\2\2\2,\u013e\3\2\2\2.\u0146\3\2\2\2\60"+
+		"\u014a\3\2\2\2\62\u0155\3\2\2\2\64\u0159\3\2\2\2\66\u015d\3\2\2\28\u016c"+
+		"\3\2\2\2:\u0175\3\2\2\2<\u0177\3\2\2\2>\u0179\3\2\2\2@\u017b\3\2\2\2B"+
+		"\u017d\3\2\2\2D\u019d\3\2\2\2F\u019f\3\2\2\2H\u01a1\3\2\2\2J\u01a3\3\2"+
+		"\2\2L\u01b0\3\2\2\2N\u01c7\3\2\2\2P\u01cc\3\2\2\2R\u01d8\3\2\2\2TV\5R"+
+		"*\2UT\3\2\2\2VW\3\2\2\2WU\3\2\2\2WX\3\2\2\2XZ\3\2\2\2Y[\7\u0089\2\2ZY"+
+		"\3\2\2\2Z[\3\2\2\2[\\\3\2\2\2\\]\7\2\2\3]\3\3\2\2\2^c\7~\2\2_c\5\6\4\2"+
+		"`c\5\n\6\2ac\5\30\r\2b^\3\2\2\2b_\3\2\2\2b`\3\2\2\2ba\3\2\2\2c\5\3\2\2"+
+		"\2df\5\66\34\2ed\3\2\2\2ef\3\2\2\2fg\3\2\2\2gr\7\u0086\2\2hr\7P\2\2ik"+
+		"\5\66\34\2ji\3\2\2\2jk\3\2\2\2kl\3\2\2\2lr\5\b\5\2mo\5\66\34\2nm\3\2\2"+
+		"\2no\3\2\2\2op\3\2\2\2pr\7j\2\2qe\3\2\2\2qh\3\2\2\2qj\3\2\2\2qn\3\2\2"+
+		"\2r\7\3\2\2\2st\t\2\2\2t\t\3\2\2\2uv\t\3\2\2v\13\3\2\2\2w\u00ca\7\u0088"+
+		"\2\2x\u00ca\7\3\2\2y\u00ca\7_\2\2z\u00ca\7`\2\2{\u00ca\7f\2\2|\u00ca\7"+
+		"a\2\2}\u00ca\3\2\2\2~\u00ca\7b\2\2\177\u00ca\7c\2\2\u0080\u00ca\7g\2\2"+
+		"\u0081\u00ca\7d\2\2\u0082\u00ca\7h\2\2\u0083\u00ca\7e\2\2\u0084\u00ca"+
+		"\7i\2\2\u0085\u00ca\7\u0087\2\2\u0086\u00ca\7B\2\2\u0087\u00ca\7,\2\2"+
+		"\u0088\u00ca\7I\2\2\u0089\u00ca\7>\2\2\u008a\u00ca\7\n\2\2\u008b\u00ca"+
+		"\7\6\2\2\u008c\u00ca\7 \2\2\u008d\u00ca\7+\2\2\u008e\u00ca\7\7\2\2\u008f"+
+		"\u00ca\7!\2\2\u0090\u00ca\7\66\2\2\u0091\u00ca\7\25\2\2\u0092\u00ca\7"+
+		"\26\2\2\u0093\u00ca\7\27\2\2\u0094\u00ca\7\30\2\2\u0095\u00ca\7\31\2\2"+
+		"\u0096\u00ca\7\32\2\2\u0097\u00ca\7\33\2\2\u0098\u00ca\7\34\2\2\u0099"+
+		"\u00ca\7\35\2\2\u009a\u00ca\7\f\2\2\u009b\u00ca\7\r\2\2\u009c\u00ca\7"+
+		"\16\2\2\u009d\u00ca\7\17\2\2\u009e\u00ca\7\20\2\2\u009f\u00ca\7\21\2\2"+
+		"\u00a0\u00ca\7\22\2\2\u00a1\u00ca\7\23\2\2\u00a2\u00ca\7\24\2\2\u00a3"+
+		"\u00ca\7;\2\2\u00a4\u00ca\7<\2\2\u00a5\u00ca\7M\2\2\u00a6\u00ca\7N\2\2"+
+		"\u00a7\u00ca\7\64\2\2\u00a8\u00ca\7G\2\2\u00a9\u00ca\7\37\2\2\u00aa\u00ca"+
+		"\7\'\2\2\u00ab\u00ca\7\b\2\2\u00ac\u00ca\7P\2\2\u00ad\u00ca\7Q\2\2\u00ae"+
+		"\u00ca\7R\2\2\u00af\u00ca\7C\2\2\u00b0\u00ca\7D\2\2\u00b1\u00ca\7%\2\2"+
+		"\u00b2\u00ca\7&\2\2\u00b3\u00ca\7.\2\2\u00b4\u00ca\7/\2\2\u00b5\u00ca"+
+		"\7\60\2\2\u00b6\u00ca\7\61\2\2\u00b7\u00ca\79\2\2\u00b8\u00ca\7:\2\2\u00b9"+
+		"\u00ca\7*\2\2\u00ba\u00ca\7)\2\2\u00bb\u00ca\7=\2\2\u00bc\u00ca\78\2\2"+
+		"\u00bd\u00ca\7\67\2\2\u00be\u00ca\7J\2\2\u00bf\u00ca\7#\2\2\u00c0\u00ca"+
+		"\7\5\2\2\u00c1\u00ca\7(\2\2\u00c2\u00ca\7\65\2\2\u00c3\u00ca\7\t\2\2\u00c4"+
+		"\u00ca\7O\2\2\u00c5\u00ca\7H\2\2\u00c6\u00ca\7\4\2\2\u00c7\u00ca\7K\2"+
+		"\2\u00c8\u00ca\7$\2\2\u00c9w\3\2\2\2\u00c9x\3\2\2\2\u00c9y\3\2\2\2\u00c9"+
+		"z\3\2\2\2\u00c9{\3\2\2\2\u00c9|\3\2\2\2\u00c9}\3\2\2\2\u00c9~\3\2\2\2"+
+		"\u00c9\177\3\2\2\2\u00c9\u0080\3\2\2\2\u00c9\u0081\3\2\2\2\u00c9\u0082"+
+		"\3\2\2\2\u00c9\u0083\3\2\2\2\u00c9\u0084\3\2\2\2\u00c9\u0085\3\2\2\2\u00c9"+
+		"\u0086\3\2\2\2\u00c9\u0087\3\2\2\2\u00c9\u0088\3\2\2\2\u00c9\u0089\3\2"+
+		"\2\2\u00c9\u008a\3\2\2\2\u00c9\u008b\3\2\2\2\u00c9\u008c\3\2\2\2\u00c9"+
+		"\u008d\3\2\2\2\u00c9\u008e\3\2\2\2\u00c9\u008f\3\2\2\2\u00c9\u0090\3\2"+
+		"\2\2\u00c9\u0091\3\2\2\2\u00c9\u0092\3\2\2\2\u00c9\u0093\3\2\2\2\u00c9"+
+		"\u0094\3\2\2\2\u00c9\u0095\3\2\2\2\u00c9\u0096\3\2\2\2\u00c9\u0097\3\2"+
+		"\2\2\u00c9\u0098\3\2\2\2\u00c9\u0099\3\2\2\2\u00c9\u009a\3\2\2\2\u00c9"+
+		"\u009b\3\2\2\2\u00c9\u009c\3\2\2\2\u00c9\u009d\3\2\2\2\u00c9\u009e\3\2"+
+		"\2\2\u00c9\u009f\3\2\2\2\u00c9\u00a0\3\2\2\2\u00c9\u00a1\3\2\2\2\u00c9"+
+		"\u00a2\3\2\2\2\u00c9\u00a3\3\2\2\2\u00c9\u00a4\3\2\2\2\u00c9\u00a5\3\2"+
+		"\2\2\u00c9\u00a6\3\2\2\2\u00c9\u00a7\3\2\2\2\u00c9\u00a8\3\2\2\2\u00c9"+
+		"\u00a9\3\2\2\2\u00c9\u00aa\3\2\2\2\u00c9\u00ab\3\2\2\2\u00c9\u00ac\3\2"+
+		"\2\2\u00c9\u00ad\3\2\2\2\u00c9\u00ae\3\2\2\2\u00c9\u00af\3\2\2\2\u00c9"+
+		"\u00b0\3\2\2\2\u00c9\u00b1\3\2\2\2\u00c9\u00b2\3\2\2\2\u00c9\u00b3\3\2"+
+		"\2\2\u00c9\u00b4\3\2\2\2\u00c9\u00b5\3\2\2\2\u00c9\u00b6\3\2\2\2\u00c9"+
+		"\u00b7\3\2\2\2\u00c9\u00b8\3\2\2\2\u00c9\u00b9\3\2\2\2\u00c9\u00ba\3\2"+
+		"\2\2\u00c9\u00bb\3\2\2\2\u00c9\u00bc\3\2\2\2\u00c9\u00bd\3\2\2\2\u00c9"+
+		"\u00be\3\2\2\2\u00c9\u00bf\3\2\2\2\u00c9\u00c0\3\2\2\2\u00c9\u00c1\3\2"+
+		"\2\2\u00c9\u00c2\3\2\2\2\u00c9\u00c3\3\2\2\2\u00c9\u00c4\3\2\2\2\u00c9"+
+		"\u00c5\3\2\2\2\u00c9\u00c6\3\2\2\2\u00c9\u00c7\3\2\2\2\u00c9\u00c8\3\2"+
+		"\2\2\u00ca\r\3\2\2\2\u00cb\u00cc\7\3\2\2\u00cc\17\3\2\2\2\u00cd\u00cf"+
+		"\7M\2\2\u00ce\u00d0\7(\2\2\u00cf\u00ce\3\2\2\2\u00cf\u00d0\3\2\2\2\u00d0"+
+		"\u00d6\3\2\2\2\u00d1\u00d3\7N\2\2\u00d2\u00d4\7\5\2\2\u00d3\u00d2\3\2"+
+		"\2\2\u00d3\u00d4\3\2\2\2\u00d4\u00d6\3\2\2\2\u00d5\u00cd\3\2\2\2\u00d5"+
+		"\u00d1\3\2\2\2\u00d6\u00d7\3\2\2\2\u00d7\u00de\5\22\n\2\u00d8\u00da\7"+
+		"T\2\2\u00d9\u00d8\3\2\2\2\u00d9\u00da\3\2\2\2\u00da\u00db\3\2\2\2\u00db"+
+		"\u00dd\5\22\n\2\u00dc\u00d9\3\2\2\2\u00dd\u00e0\3\2\2\2\u00de\u00dc\3"+
+		"\2\2\2\u00de\u00df\3\2\2\2\u00df\21\3\2\2\2\u00e0\u00de\3\2\2\2\u00e1"+
+		"\u00e3\5\24\13\2\u00e2\u00e4\5\26\f\2\u00e3\u00e2\3\2\2\2\u00e3\u00e4"+
+		"\3\2\2\2\u00e4\23\3\2\2\2\u00e5\u00e6\5\4\3\2\u00e6\25\3\2\2\2\u00e7\u00e8"+
+		"\5\16\b\2\u00e8\u00e9\5\4\3\2\u00e9\27\3\2\2\2\u00ea\u00eb\7\4\2\2\u00eb"+
+		"\u00fa\5\4\3\2\u00ec\u00fa\7%\2\2\u00ed\u00fa\7&\2\2\u00ee\u00fa\7.\2"+
+		"\2\u00ef\u00fa\7/\2\2\u00f0\u00fa\7\60\2\2\u00f1\u00fa\7\61\2\2\u00f2"+
+		"\u00fa\79\2\2\u00f3\u00fa\7:\2\2\u00f4\u00fa\7C\2\2\u00f5\u00fa\7D\2\2"+
+		"\u00f6\u00fa\7P\2\2\u00f7\u00fa\7Q\2\2\u00f8\u00fa\7R\2\2\u00f9\u00ea"+
+		"\3\2\2\2\u00f9\u00ec\3\2\2\2\u00f9\u00ed\3\2\2\2\u00f9\u00ee\3\2\2\2\u00f9"+
+		"\u00ef\3\2\2\2\u00f9\u00f0\3\2\2\2\u00f9\u00f1\3\2\2\2\u00f9\u00f2\3\2"+
+		"\2\2\u00f9\u00f3\3\2\2\2\u00f9\u00f4\3\2\2\2\u00f9\u00f5\3\2\2\2\u00f9"+
+		"\u00f6\3\2\2\2\u00f9\u00f7\3\2\2\2\u00f9\u00f8\3\2\2\2\u00fa\31\3\2\2"+
+		"\2\u00fb\u00fd\t\4\2\2\u00fc\u00fe\7+\2\2\u00fd\u00fc\3\2\2\2\u00fd\u00fe"+
+		"\3\2\2\2\u00fe\u0100\3\2\2\2\u00ff\u0101\7(\2\2\u0100\u00ff\3\2\2\2\u0100"+
+		"\u0101\3\2\2\2\u0101\u0102\3\2\2\2\u0102\u0103\5\f\7\2\u0103\33\3\2\2"+
+		"\2\u0104\u0105\7H\2\2\u0105\u0106\5\b\5\2\u0106\35\3\2\2\2\u0107\u0109"+
+		"\7\37\2\2\u0108\u010a\7\65\2\2\u0109\u0108\3\2\2\2\u0109\u010a\3\2\2\2"+
+		"\u010a\u010b\3\2\2\2\u010b\u010c\5\f\7\2\u010c\37\3\2\2\2\u010d\u010f"+
+		"\7\'\2\2\u010e\u0110\7\t\2\2\u010f\u010e\3\2\2\2\u010f\u0110\3\2\2\2\u0110"+
+		"\u0111\3\2\2\2\u0111\u0118\5\f\7\2\u0112\u0114\7T\2\2\u0113\u0112\3\2"+
+		"\2\2\u0113\u0114\3\2\2\2\u0114\u0115\3\2\2\2\u0115\u0117\7\u0088\2\2\u0116"+
+		"\u0113\3\2\2\2\u0117\u011a\3\2\2\2\u0118\u0116\3\2\2\2\u0118\u0119\3\2"+
+		"\2\2\u0119!\3\2\2\2\u011a\u0118\3\2\2\2\u011b\u011c\7\64\2\2\u011c\u011e"+
+		"\5\b\5\2\u011d\u011f\5\34\17\2\u011e\u011d\3\2\2\2\u011e\u011f\3\2\2\2"+
+		"\u011f\u0121\3\2\2\2\u0120\u0122\7G\2\2\u0121\u0120\3\2\2\2\u0121\u0122"+
+		"\3\2\2\2\u0122\u0124\3\2\2\2\u0123\u0125\5\36\20\2\u0124\u0123\3\2\2\2"+
+		"\u0124\u0125\3\2\2\2\u0125\u0127\3\2\2\2\u0126\u0128\5\32\16\2\u0127\u0126"+
+		"\3\2\2\2\u0127\u0128\3\2\2\2\u0128\u012a\3\2\2\2\u0129\u012b\5 \21\2\u012a"+
+		"\u0129\3\2\2\2\u012a\u012b\3\2\2\2\u012b#\3\2\2\2\u012c\u012d\7;\2\2\u012d"+
+		"\u012e\5\f\7\2\u012e%\3\2\2\2\u012f\u0130\7<\2\2\u0130\u0134\5\f\7\2\u0131"+
+		"\u0132\5\16\b\2\u0132\u0133\5\f\7\2\u0133\u0135\3\2\2\2\u0134\u0131\3"+
+		"\2\2\2\u0134\u0135\3\2\2\2\u0135\'\3\2\2\2\u0136\u0137\t\5\2\2\u0137)"+
+		"\3\2\2\2\u0138\u0139\t\6\2\2\u0139+\3\2\2\2\u013a\u013c\7K\2\2\u013b\u013d"+
+		"\7(\2\2\u013c\u013b\3\2\2\2\u013c\u013d\3\2\2\2\u013d\u013f\3\2\2\2\u013e"+
+		"\u013a\3\2\2\2\u013e\u013f\3\2\2\2\u013f\u0140\3\2\2\2\u0140\u0141\5("+
+		"\25\2\u0141-\3\2\2\2\u0142\u0144\7K\2\2\u0143\u0145\7(\2\2\u0144\u0143"+
+		"\3\2\2\2\u0144\u0145\3\2\2\2\u0145\u0147\3\2\2\2\u0146\u0142\3\2\2\2\u0146"+
+		"\u0147\3\2\2\2\u0147\u0148\3\2\2\2\u0148\u0149\5*\26\2\u0149/\3\2\2\2"+
+		"\u014a\u014c\7B\2\2\u014b\u014d\7(\2\2\u014c\u014b\3\2\2\2\u014c\u014d"+
+		"\3\2\2\2\u014d\u014e\3\2\2\2\u014e\u0150\t\7\2\2\u014f\u0151\7>\2\2\u0150"+
+		"\u014f\3\2\2\2\u0150\u0151\3\2\2\2\u0151\u0153\3\2\2\2\u0152\u0154\7\n"+
+		"\2\2\u0153\u0152\3\2\2\2\u0153\u0154\3\2\2\2\u0154\61\3\2\2\2\u0155\u0157"+
+		"\t\b\2\2\u0156\u0158\7=\2\2\u0157\u0156\3\2\2\2\u0157\u0158\3\2\2\2\u0158"+
+		"\63\3\2\2\2\u0159\u015a\7\\\2\2\u015a\65\3\2\2\2\u015b\u015e\7X\2\2\u015c"+
+		"\u015e\7W\2\2\u015d\u015b\3\2\2\2\u015d\u015c\3\2\2\2\u015e\67\3\2\2\2"+
+		"\u015f\u016d\7^\2\2\u0160\u016d\7c\2\2\u0161\u016d\7`\2\2\u0162\u016d"+
+		"\7d\2\2\u0163\u016d\7e\2\2\u0164\u016d\7j\2\2\u0165\u016d\7k\2\2\u0166"+
+		"\u016d\7l\2\2\u0167\u016d\7m\2\2\u0168\u016d\7n\2\2\u0169\u016d\7o\2\2"+
+		"\u016a\u016d\7p\2\2\u016b\u016d\7q\2\2\u016c\u015f\3\2\2\2\u016c\u0160"+
+		"\3\2\2\2\u016c\u0161\3\2\2\2\u016c\u0162\3\2\2\2\u016c\u0163\3\2\2\2\u016c"+
+		"\u0164\3\2\2\2\u016c\u0165\3\2\2\2\u016c\u0166\3\2\2\2\u016c\u0167\3\2"+
+		"\2\2\u016c\u0168\3\2\2\2\u016c\u0169\3\2\2\2\u016c\u016a\3\2\2\2\u016c"+
+		"\u016b\3\2\2\2\u016d9\3\2\2\2\u016e\u0170\5\66\34\2\u016f\u016e\3\2\2"+
+		"\2\u016f\u0170\3\2\2\2\u0170\u0171\3\2\2\2\u0171\u0176\58\35\2\u0172\u0173"+
+		"\58\35\2\u0173\u0174\5\66\34\2\u0174\u0176\3\2\2\2\u0175\u016f\3\2\2\2"+
+		"\u0175\u0172\3\2\2\2\u0176;\3\2\2\2\u0177\u0178\t\t\2\2\u0178=\3\2\2\2"+
+		"\u0179\u017a\t\n\2\2\u017a?\3\2\2\2\u017b\u017c\t\13\2\2\u017cA\3\2\2"+
+		"\2\u017d\u017e\t\f\2\2\u017eC\3\2\2\2\u017f\u018d\5B\"\2\u0180\u018e\5"+
+		"<\37\2\u0181\u018e\5@!\2\u0182\u018e\5> \2\u0183\u0185\5:\36\2\u0184\u0186"+
+		"\5,\27\2\u0185\u0184\3\2\2\2\u0185\u0186\3\2\2\2\u0186\u018c\3\2\2\2\u0187"+
+		"\u0189\5,\27\2\u0188\u0187\3\2\2\2\u0188\u0189\3\2\2\2\u0189\u018a\3\2"+
+		"\2\2\u018a\u018c\5:\36\2\u018b\u0183\3\2\2\2\u018b\u0188\3\2\2\2\u018c"+
+		"\u018e\3\2\2\2\u018d\u0180\3\2\2\2\u018d\u0181\3\2\2\2\u018d\u0182\3\2"+
+		"\2\2\u018d\u018b\3\2\2\2\u018e\u019e\3\2\2\2\u018f\u0191\7K\2\2\u0190"+
+		"\u0192\7(\2\2\u0191\u0190\3\2\2\2\u0191\u0192\3\2\2\2\u0192\u0194\3\2"+
+		"\2\2\u0193\u018f\3\2\2\2\u0193\u0194\3\2\2\2\u0194\u0195\3\2\2\2\u0195"+
+		"\u019e\7\16\2\2\u0196\u0198\7K\2\2\u0197\u0199\7(\2\2\u0198\u0197\3\2"+
+		"\2\2\u0198\u0199\3\2\2\2\u0199\u019b\3\2\2\2\u019a\u0196\3\2\2\2\u019a"+
+		"\u019b\3\2\2\2\u019b\u019c\3\2\2\2\u019c\u019e\7\17\2\2\u019d\u017f\3"+
+		"\2\2\2\u019d\u0193\3\2\2\2\u019d\u019a\3\2\2\2\u019eE\3\2\2\2\u019f\u01a0"+
+		"\t\r\2\2\u01a0G\3\2\2\2\u01a1\u01a2\t\16\2\2\u01a2I\3\2\2\2\u01a3\u01a4"+
+		"\5F$\2\u01a4\u01ab\5\f\7\2\u01a5\u01aa\5$\23\2\u01a6\u01aa\5.\30\2\u01a7"+
+		"\u01aa\5\"\22\2\u01a8\u01aa\5\20\t\2\u01a9\u01a5\3\2\2\2\u01a9\u01a6\3"+
+		"\2\2\2\u01a9\u01a7\3\2\2\2\u01a9\u01a8\3\2\2\2\u01aa\u01ad\3\2\2\2\u01ab"+
+		"\u01a9\3\2\2\2\u01ab\u01ac\3\2\2\2\u01ac\u01ae\3\2\2\2\u01ad\u01ab\3\2"+
+		"\2\2\u01ae\u01af\5\64\33\2\u01afK\3\2\2\2\u01b0\u01b1\5F$\2\u01b1\u01bb"+
+		"\5\f\7\2\u01b2\u01ba\5\62\32\2\u01b3\u01ba\5\"\22\2\u01b4\u01ba\5D#\2"+
+		"\u01b5\u01ba\5$\23\2\u01b6\u01ba\5,\27\2\u01b7\u01ba\5\20\t\2\u01b8\u01ba"+
+		"\5\60\31\2\u01b9\u01b2\3\2\2\2\u01b9\u01b3\3\2\2\2\u01b9\u01b4\3\2\2\2"+
+		"\u01b9\u01b5\3\2\2\2\u01b9\u01b6\3\2\2\2\u01b9\u01b7\3\2\2\2\u01b9\u01b8"+
+		"\3\2\2\2\u01ba\u01bd\3\2\2\2\u01bb\u01b9\3\2\2\2\u01bb\u01bc\3\2\2\2\u01bc"+
+		"\u01c3\3\2\2\2\u01bd\u01bb\3\2\2\2\u01be\u01c0\7\b\2\2\u01bf\u01c1\7O"+
+		"\2\2\u01c0\u01bf\3\2\2\2\u01c0\u01c1\3\2\2\2\u01c1\u01c2\3\2\2\2\u01c2"+
+		"\u01c4\7P\2\2\u01c3\u01be\3\2\2\2\u01c3\u01c4\3\2\2\2\u01c4\u01c5\3\2"+
+		"\2\2\u01c5\u01c6\5\64\33\2\u01c6M\3\2\2\2\u01c7\u01c8\7\u0081\2\2\u01c8"+
+		"\u01c9\5\f\7\2\u01c9\u01ca\5&\24\2\u01ca\u01cb\5\64\33\2\u01cbO\3\2\2"+
+		"\2\u01cc\u01cd\7\u0083\2\2\u01cd\u01ce\5\f\7\2\u01ce\u01cf\5\20\t\2\u01cf"+
+		"\u01d0\5\64\33\2\u01d0Q\3\2\2\2\u01d1\u01d9\7]\2\2\u01d2\u01d9\5J&\2\u01d3"+
+		"\u01d9\5L\'\2\u01d4\u01d9\5N(\2\u01d5\u01d9\5P)\2\u01d6\u01d9\5H%\2\u01d7"+
+		"\u01d9\5\64\33\2\u01d8\u01d1\3\2\2\2\u01d8\u01d2\3\2\2\2\u01d8\u01d3\3"+
+		"\2\2\2\u01d8\u01d4\3\2\2\2\u01d8\u01d5\3\2\2\2\u01d8\u01d6\3\2\2\2\u01d8"+
+		"\u01d7\3\2\2\2\u01d9S\3\2\2\29WZbejnq\u00c9\u00cf\u00d3\u00d5\u00d9\u00de"+
+		"\u00e3\u00f9\u00fd\u0100\u0109\u010f\u0113\u0118\u011e\u0121\u0124\u0127"+
+		"\u012a\u0134\u013c\u013e\u0144\u0146\u014c\u0150\u0153\u0157\u015d\u016c"+
+		"\u016f\u0175\u0185\u0188\u018b\u018d\u0191\u0193\u0198\u019a\u019d\u01a9"+
+		"\u01ab\u01b9\u01bb\u01c0\u01c3\u01d8";
 	public static final ATN _ATN =
 		new ATNDeserializer().deserialize(_serializedATN.toCharArray());
 	static {

--- a/cobol-parser/src/test/scala/za/co/absa/cobrix/cobol/parser/parse/SyntaxErrorsSpec.scala
+++ b/cobol-parser/src/test/scala/za/co/absa/cobrix/cobol/parser/parse/SyntaxErrorsSpec.scala
@@ -214,6 +214,9 @@ class SyntaxErrorsSpec extends AnyFunSuite with SimpleComparisonBase {
         |          10  FIELD    PIC +999.
         |          10  FIELD    PIC -9999.
         |          10  FIELD    PIC 99999+.
+        |          10  FIELD    PIC +999.9999.
+        |              88 VALUE1  VALUE +999.9999.
+        |              88 VALUE2  VALUE +951.22.
         |""".stripMargin
 
     //           10  FIELD    PIC 9(4)9-.  <-- is this valid?


### PR DESCRIPTION
Closes #727

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for optionally signed numeric literals with explicit decimal notation in COBOL copybooks.
  * Improved parsing of precision-9 decimal values in PIC clauses.

* **Bug Fixes**
  * Valid explicit-decimal PIC definitions, including condition-name entries, are now parsed correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->